### PR TITLE
Tb 2901 tooltip example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
-import 'package:example/resources.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:xayn_design/xayn_design.dart';
+
+import 'screen/linden_screen.dart';
 
 void main() {
   /// Instead of passing [Linden] as a parameter, it's better to injected it
@@ -37,96 +37,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: linden.themeData,
-      home: MyHomePage(linden, onThemeChange),
+      home: LindenScreen(linden, onThemeChange),
     );
   }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage(
-    this.linden,
-    this.onThemeChange, {
-    Key? key,
-  }) : super(key: key);
-  final Linden linden;
-  final Function(Brightness) onThemeChange;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  Linden get linden => widget.linden;
-  bool get isDark => linden.brightness == Brightness.dark;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Xayn Design Library (Linden)'),
-      ),
-      body: _buildListView(),
-      floatingActionButton: _buildThemeTogglerButton(),
-    );
-  }
-
-  ListView _buildListView() => ListView(
-        children: [
-          _buildHeadline('Icons'),
-          _buildAssetsGrid(
-            getIconAssets(linden),
-            color: linden.colors.icon,
-          ),
-          SizedBox(height: linden.dimen.unit3),
-          _buildHeadline('Graphics'),
-          _buildAssetsGrid(
-            getGraphicsAssets(linden),
-            backgroundColor: linden.colors.iconDisabled,
-          ),
-          SizedBox(height: linden.dimen.unit3),
-          _buildHeadline('Logos'),
-          _buildAssetsGrid(getLogoAssets(linden)),
-          SizedBox(height: linden.dimen.unit3),
-          _buildHeadline('Illustrations'),
-          _buildAssetsGrid(getIllustrationsAssets(linden)),
-        ],
-      );
-
-  Padding _buildHeadline(String str) => Padding(
-        child: Text(str, style: linden.styles.appScreenHeadline),
-        padding: EdgeInsets.only(bottom: linden.dimen.unit2),
-      );
-
-  FloatingActionButton _buildThemeTogglerButton() => FloatingActionButton(
-        onPressed: () =>
-            widget.onThemeChange(isDark ? Brightness.light : Brightness.dark),
-        tooltip: 'Toggle Theme',
-        child: SvgPicture.asset(
-          isDark ? linden.assets.icons.sun : linden.assets.icons.moon,
-          color: linden.colors.brightIcon,
-        ),
-      );
-
-  GridView _buildAssetsGrid(
-    List<String> icons, {
-    Color? color,
-    Color? backgroundColor,
-  }) =>
-      GridView.builder(
-        shrinkWrap: true,
-        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-          maxCrossAxisExtent: 50,
-          crossAxisSpacing: 5,
-        ),
-        itemCount: icons.length,
-        itemBuilder: (context, index) {
-          return Container(
-            color: backgroundColor,
-            child: SvgPicture.asset(
-              icons[index],
-              color: color,
-            ),
-          );
-        },
-      );
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-import 'screen/linden_screen.dart';
+import 'screen/main_screen.dart';
 
 void main() {
   final unterDenLinden = UnterDenLinden(
@@ -25,7 +25,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: UnterDenLinden.getLinden(context).themeData,
-      home: const LindenScreen(),
+      home: const MainScreen(),
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,40 +4,28 @@ import 'package:xayn_design/xayn_design.dart';
 import 'screen/linden_screen.dart';
 
 void main() {
-  /// Instead of passing [Linden] as a parameter, it's better to injected it
-  /// using your preferred state management package
-  runApp(MyApp(Linden()));
+  final unterDenLinden = UnterDenLinden(
+    child: const MyApp(),
+    initialLinden: Linden(),
+    onLindenUpdated: (final Linden newLinden) {
+      print('Yay, linden was updated');
+    },
+  );
+
+  runApp(unterDenLinden);
 }
 
-class MyApp extends StatefulWidget {
-  const MyApp(this.linden, {Key? key}) : super(key: key);
-  final Linden linden;
-
-  @override
-  _MyAppState createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  late Linden linden;
-
-  @override
-  void initState() {
-    linden = widget.linden;
-    super.initState();
-  }
-
-  onThemeChange(Brightness brightness) {
-    setState(() {
-      linden = linden.updateBrightness(brightness);
-    });
-  }
+class MyApp extends StatelessWidget {
+  const MyApp({
+    Key? key,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
-      theme: linden.themeData,
-      home: LindenScreen(linden, onThemeChange),
+      theme: UnterDenLinden.getLinden(context).themeData,
+      home: const LindenScreen(),
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,13 +1,20 @@
+import 'package:example/screen/linden_screen.dart';
+import 'package:example/screen/widgets_screen.dart';
+import 'package:example/utils/tooltip_keys.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 import 'screen/main_screen.dart';
 
 void main() {
   final unterDenLinden = UnterDenLinden(
-    child: const MyApp(),
+    child: MyApp(),
     initialLinden: Linden(),
     onLindenUpdated: (final Linden newLinden) {
+      //ignore: avoid_print
       print('Yay, linden was updated');
     },
   );
@@ -16,16 +23,58 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({
+  final _tooltipController = TooltipController();
+  final _applicationTooltipController = ApplicationTooltipController();
+
+  MyApp({
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    final materialApp = MaterialApp(
       title: 'Flutter Demo',
       theme: UnterDenLinden.getLinden(context).themeData,
-      home: const MainScreen(),
+      onGenerateRoute: createCupertinoPageRoute,
+    );
+    return MultiProvider(
+      providers: _getProviders(),
+      child: materialApp,
+    );
+  }
+
+  List<SingleChildWidget> _getProviders() => [
+        ChangeNotifierProvider<TooltipController>.value(
+            value: _tooltipController),
+        Provider<ApplicationTooltipController>.value(
+            value: _applicationTooltipController),
+      ];
+
+  PageRoute? createCupertinoPageRoute(RouteSettings routeSettings) {
+    late final Widget? screenWidget;
+    switch (routeSettings.name) {
+      case MainScreen.routeName:
+        screenWidget = const MainScreen();
+        break;
+      case LindenScreen.routeName:
+        screenWidget = const LindenScreen();
+        break;
+      case WidgetsScreen.routeName:
+        screenWidget = const WidgetsScreen();
+        break;
+      default:
+        screenWidget = null;
+    }
+
+    if (screenWidget == null) {
+      return null;
+    }
+    return CupertinoPageRoute(
+      builder: (_) => ApplicationTooltipProvider(
+        messageFactory: TooltipMessageProvider.of(),
+        child: screenWidget,
+      ),
+      settings: routeSettings,
     );
   }
 }

--- a/example/lib/screen/linden_screen.dart
+++ b/example/lib/screen/linden_screen.dart
@@ -4,20 +4,18 @@ import 'package:xayn_design/xayn_design.dart';
 import '../resources.dart';
 
 class LindenScreen extends StatefulWidget {
-  const LindenScreen(
-    this.linden,
-    this.onThemeChange, {
+  static const routeName = '/linden';
+
+  const LindenScreen({
     Key? key,
   }) : super(key: key);
-  final Linden linden;
-  final Function(Brightness) onThemeChange;
 
   @override
   State<LindenScreen> createState() => _LindenScreenState();
 }
 
 class _LindenScreenState extends State<LindenScreen> {
-  Linden get linden => widget.linden;
+  Linden get linden => UnterDenLinden.getLinden(context);
 
   bool get isDark => linden.brightness == Brightness.dark;
 
@@ -60,8 +58,10 @@ class _LindenScreenState extends State<LindenScreen> {
       );
 
   FloatingActionButton _buildThemeTogglerButton() => FloatingActionButton(
-        onPressed: () =>
-            widget.onThemeChange(isDark ? Brightness.light : Brightness.dark),
+        onPressed: () {
+          final brightness = isDark ? Brightness.light : Brightness.dark;
+          UnterDenLinden.of(context).changeBrightness(brightness);
+        },
         tooltip: 'Toggle Theme',
         child: SvgPicture.asset(
           isDark ? linden.assets.icons.sun : linden.assets.icons.moon,

--- a/example/lib/screen/linden_screen.dart
+++ b/example/lib/screen/linden_screen.dart
@@ -23,7 +23,7 @@ class _LindenScreenState extends State<LindenScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Xayn Design Library (Linden)'),
+        title: const Text('Xayn Linden'),
       ),
       body: _buildListView(),
       floatingActionButton: _buildThemeTogglerButton(),

--- a/example/lib/screen/linden_screen.dart
+++ b/example/lib/screen/linden_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+import '../resources.dart';
+
+class LindenScreen extends StatefulWidget {
+  const LindenScreen(
+    this.linden,
+    this.onThemeChange, {
+    Key? key,
+  }) : super(key: key);
+  final Linden linden;
+  final Function(Brightness) onThemeChange;
+
+  @override
+  State<LindenScreen> createState() => _LindenScreenState();
+}
+
+class _LindenScreenState extends State<LindenScreen> {
+  Linden get linden => widget.linden;
+
+  bool get isDark => linden.brightness == Brightness.dark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Xayn Design Library (Linden)'),
+      ),
+      body: _buildListView(),
+      floatingActionButton: _buildThemeTogglerButton(),
+    );
+  }
+
+  ListView _buildListView() => ListView(
+        children: [
+          _buildHeadline('Icons'),
+          _buildAssetsGrid(
+            getIconAssets(linden),
+            color: linden.colors.icon,
+          ),
+          SizedBox(height: linden.dimen.unit3),
+          _buildHeadline('Graphics'),
+          _buildAssetsGrid(
+            getGraphicsAssets(linden),
+            backgroundColor: linden.colors.iconDisabled,
+          ),
+          SizedBox(height: linden.dimen.unit3),
+          _buildHeadline('Logos'),
+          _buildAssetsGrid(getLogoAssets(linden)),
+          SizedBox(height: linden.dimen.unit3),
+          _buildHeadline('Illustrations'),
+          _buildAssetsGrid(getIllustrationsAssets(linden)),
+        ],
+      );
+
+  Padding _buildHeadline(String str) => Padding(
+        child: Text(str, style: linden.styles.appScreenHeadline),
+        padding: EdgeInsets.only(bottom: linden.dimen.unit2),
+      );
+
+  FloatingActionButton _buildThemeTogglerButton() => FloatingActionButton(
+        onPressed: () =>
+            widget.onThemeChange(isDark ? Brightness.light : Brightness.dark),
+        tooltip: 'Toggle Theme',
+        child: SvgPicture.asset(
+          isDark ? linden.assets.icons.sun : linden.assets.icons.moon,
+          color: linden.colors.brightIcon,
+        ),
+      );
+
+  GridView _buildAssetsGrid(
+    List<String> icons, {
+    Color? color,
+    Color? backgroundColor,
+  }) =>
+      GridView.builder(
+        shrinkWrap: true,
+        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: 50,
+          crossAxisSpacing: 5,
+        ),
+        itemCount: icons.length,
+        itemBuilder: (context, index) {
+          return Container(
+            color: backgroundColor,
+            child: SvgPicture.asset(
+              icons[index],
+              color: color,
+            ),
+          );
+        },
+      );
+}

--- a/example/lib/screen/main_screen.dart
+++ b/example/lib/screen/main_screen.dart
@@ -1,7 +1,10 @@
 import 'package:example/screen/linden_screen.dart';
+import 'package:example/screen/widgets_screen.dart';
 import 'package:flutter/material.dart';
 
 class MainScreen extends StatefulWidget {
+  static const routeName = '/';
+
   const MainScreen({Key? key}) : super(key: key);
 
   @override
@@ -14,6 +17,7 @@ class _MainScreenState extends State<MainScreen> {
     final content = Column(
       children: [
         _buildLindenBtn(),
+        _buildWidgetsBtn(),
       ],
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
     );
@@ -24,14 +28,17 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   Widget _buildLindenBtn() => _buildButton('Show Linden', () {
-        _pushScreen(const LindenScreen());
+        _pushScreen(LindenScreen.routeName);
+      });
+
+  Widget _buildWidgetsBtn() => _buildButton('Show widgets', () {
+        _pushScreen(WidgetsScreen.routeName);
       });
 
   Widget _buildButton(String text, VoidCallback onPressed) => Center(
         child: ElevatedButton(onPressed: onPressed, child: Text(text)),
       );
 
-  void _pushScreen(Widget screen) {
-    Navigator.of(context).push(MaterialPageRoute(builder: (_) => screen));
-  }
+  void _pushScreen(String routeName) =>
+      Navigator.of(context).pushNamed(routeName);
 }

--- a/example/lib/screen/main_screen.dart
+++ b/example/lib/screen/main_screen.dart
@@ -1,0 +1,37 @@
+import 'package:example/screen/linden_screen.dart';
+import 'package:flutter/material.dart';
+
+class MainScreen extends StatefulWidget {
+  const MainScreen({Key? key}) : super(key: key);
+
+  @override
+  _MainScreenState createState() => _MainScreenState();
+}
+
+class _MainScreenState extends State<MainScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final content = Column(
+      children: [
+        _buildLindenBtn(),
+      ],
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    );
+    return Scaffold(
+      appBar: AppBar(title: const Text('Xayn Design Library')),
+      body: content,
+    );
+  }
+
+  Widget _buildLindenBtn() => _buildButton('Show Linden', () {
+        _pushScreen(const LindenScreen());
+      });
+
+  Widget _buildButton(String text, VoidCallback onPressed) => Center(
+        child: ElevatedButton(onPressed: onPressed, child: Text(text)),
+      );
+
+  void _pushScreen(Widget screen) {
+    Navigator.of(context).push(MaterialPageRoute(builder: (_) => screen));
+  }
+}

--- a/example/lib/screen/widgets_screen.dart
+++ b/example/lib/screen/widgets_screen.dart
@@ -1,0 +1,82 @@
+import 'package:example/utils/tooltip_keys.dart';
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class WidgetsScreen extends StatefulWidget {
+  static const routeName = '/widgets';
+
+  const WidgetsScreen({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<WidgetsScreen> createState() => _WidgetsScreenState();
+}
+
+class _WidgetsScreenState extends State<WidgetsScreen> with TooltipStateMixin {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  @override
+  void initState() {
+    WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+      _registerDynamicTooltips();
+    });
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Column(
+      children: [
+        _buildSimpleTooltipBtn(),
+      ],
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    );
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Xayn widgets'),
+      ),
+      body: content,
+      floatingActionButton: _buildUndoButton(),
+    );
+  }
+
+  void _registerDynamicTooltips() {
+    final linden = this.linden;
+    registerTooltip(
+      key: TooltipKeys.withIcon,
+      params: TooltipParams(
+        label: 'Undo action',
+        builder: (_) => TextualNotification(
+          icon: linden.assets.icons.undo,
+          onTap: (parameters) {
+            //ignore: avoid_print
+            print('undo action clicked');
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUndoButton() {
+    final fab = FloatingActionButton(
+      onPressed: () {
+        showTooltip(TooltipKeys.withIcon);
+      },
+      tooltip: 'Show undo',
+      child: SvgPicture.asset(
+        linden.assets.icons.undo,
+        color: linden.colors.brightIcon,
+      ),
+    );
+    return TooltipContextProvider(child: fab);
+  }
+
+  Widget _buildSimpleTooltipBtn() => _buildButton('Show simple tooltip', () {
+        showTooltip(TooltipKeys.simple);
+      });
+
+  Widget _buildButton(String text, VoidCallback onPressed) => Center(
+        child: ElevatedButton(onPressed: onPressed, child: Text(text)),
+      );
+}

--- a/example/lib/utils/tooltip_keys.dart
+++ b/example/lib/utils/tooltip_keys.dart
@@ -1,0 +1,19 @@
+import 'package:xayn_design/xayn_design.dart';
+
+class TooltipKeys {
+  TooltipKeys._();
+
+  static const simple = TooltipKey('simple');
+  static const withIcon = TooltipKey('with_icon');
+}
+
+abstract class TooltipMessageProvider {
+  TooltipMessageProvider._();
+
+  static MessageFactory of() => {
+        TooltipKeys.simple: TooltipParams(
+          label: 'This is simple tooltip',
+          builder: (_) => const TextualNotification(),
+        ),
+      };
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   xayn_design:
     path: ../../xayn_design
+  provider: 6.0.0
 
 dev_dependencies:
   flutter_lints: ^1.0.0

--- a/lib/src/widget/tooltip/application_tooltip_provider.dart
+++ b/lib/src/widget/tooltip/application_tooltip_provider.dart
@@ -9,11 +9,9 @@ import 'package:xayn_design/xayn_design.dart';
 /// which will be used for laying out the actual [Tooltip].
 class ApplicationTooltipProvider extends SingleChildStatefulWidget {
   final MessageFactory messageFactory;
-  final Linden linden;
 
   const ApplicationTooltipProvider({
     required this.messageFactory,
-    required this.linden,
     required Widget? child,
     Key? key,
   }) : super(key: key, child: child);
@@ -27,7 +25,6 @@ class _ApplicationTooltipProviderState
   @override
   Widget buildWithChild(BuildContext context, Widget? child) {
     return Tooltip.contextDeferred(
-      linden: widget.linden,
       messageFactory: widget.messageFactory,
       preferBelow: false,
       contextProvider: () {

--- a/lib/src/widget/tooltip/messages/textual_notification.dart
+++ b/lib/src/widget/tooltip/messages/textual_notification.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:xayn_design/src/widget/unter_den_linden/unter_den_linden_mixin.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 const Duration kTimeToLive = Duration(seconds: 3);
@@ -6,13 +7,11 @@ const Duration kTimeToLive = Duration(seconds: 3);
 typedef ParameterCallback = void Function(List<dynamic>? parameters);
 
 class TextualNotification extends TooltipMessage {
-  final Linden linden;
   final double? width, height;
   final String? icon;
   final ParameterCallback? onTap;
 
   const TextualNotification({
-    required this.linden,
     Key? key,
     this.width,
     this.height,
@@ -25,7 +24,7 @@ class TextualNotification extends TooltipMessage {
 }
 
 class _TextualNotificationState extends State<TextualNotification>
-    with TooltipControllerProviderMixin {
+    with TooltipControllerProviderMixin, UnterDenLindenMixin {
   @override
   Widget build(BuildContext context) {
     final icon = widget.icon;
@@ -36,10 +35,10 @@ class _TextualNotificationState extends State<TextualNotification>
         if (icon != null) ...[
           SvgPicture.asset(
             icon,
-            color: widget.linden.colors.primary,
+            color: linden.colors.primary,
           ),
           SizedBox(
-            width: widget.linden.dimen.unit,
+            width: linden.dimen.unit,
           )
         ],
         if (tooltipController.activeKey != null)
@@ -61,7 +60,7 @@ class _TextualNotificationState extends State<TextualNotification>
         tooltipController.hide();
       },
       child: TooltipMessageContainer(
-        linden: widget.linden,
+        linden: linden,
         child: content,
       ),
     );

--- a/lib/src/widget/tooltip/tooltip.dart
+++ b/lib/src/widget/tooltip/tooltip.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
+import 'package:xayn_design/src/widget/unter_den_linden/unter_den_linden_mixin.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 const Duration kFadeInDuration = Duration(milliseconds: 150);
@@ -21,7 +22,6 @@ class Tooltip extends StatefulWidget {
   final TooltipController? controller;
   final ContextProvider? contextProvider;
   final MessageFactory messageFactory;
-  final Linden linden;
   final double? height;
   final double? verticalOffset;
   final Widget? child;
@@ -35,7 +35,6 @@ class Tooltip extends StatefulWidget {
   const Tooltip({
     Key? key,
     required this.messageFactory,
-    required this.linden,
     this.height,
     this.verticalOffset,
     this.child,
@@ -52,7 +51,6 @@ class Tooltip extends StatefulWidget {
   Tooltip.contextDeferred({
     Key? key,
     required this.messageFactory,
-    required this.linden,
     this.contextProvider,
     this.height,
     this.verticalOffset,
@@ -203,7 +201,8 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
   }
 }
 
-class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
+class _TooltipState extends State<Tooltip>
+    with SingleTickerProviderStateMixin, UnterDenLindenMixin {
   late double height;
   late double verticalOffset;
   late AnimationController animationController;
@@ -216,7 +215,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     assert(Overlay.of(context, debugRequiredFor: widget) != null);
 
     height = widget.height ?? _getDefaultTooltipHeight();
-    verticalOffset = widget.verticalOffset ?? widget.linden.dimen.unit4;
+    verticalOffset = widget.verticalOffset ?? linden.dimen.unit4;
 
     return ChangeNotifierProvider<TooltipController>.value(
       value: tooltipController,
@@ -262,7 +261,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
           targetContext.size!.center(Offset.zero),
           ancestor: overlayState.context.findRenderObject(),
         );
-
+    final linden = this.linden;
     // We create this widget outside of the overlay entry's builder to prevent
     // updated values from happening to leak into the overlay when the overlay
     // rebuilds.
@@ -273,7 +272,7 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
         onBuild: calculateCurrentOffset,
         initialValue: calculateCurrentOffset(),
         builder: (context, Offset? offset) => _TooltipOverlay(
-          linden: widget.linden,
+          linden: linden,
           messageFactory: messageFactory,
           tooltipKey: tooltipKey,
           height: height,
@@ -318,9 +317,9 @@ class _TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return widget.linden.dimen.unit3;
+        return linden.dimen.unit3;
       default:
-        return widget.linden.dimen.unit4;
+        return linden.dimen.unit4;
     }
   }
 

--- a/lib/src/widget/unter_den_linden/unter_den_linden.dart
+++ b/lib/src/widget/unter_den_linden/unter_den_linden.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+typedef OnLindenUpdated = Function(Linden linden);
+
+/// Should be the highest level widget in the three.
+/// Maintain updating application widget tree when [Linden] changes
+class UnterDenLinden extends StatefulWidget {
+  /// Ideally this should be the app widget
+  final Widget child;
+
+  /// Initial value of the [Linden]
+  final Linden initialLinden;
+
+  /// Add this callback if you would like to be notified when [Linden] changed
+  /// inside [_UnterDenLindenState]
+  final OnLindenUpdated? onLindenUpdated;
+
+  const UnterDenLinden({
+    Key? key,
+    required this.child,
+    required this.initialLinden,
+    this.onLindenUpdated,
+  }) : super(key: key);
+
+  @override
+  _UnterDenLindenState createState() => _UnterDenLindenState();
+
+  /// Allows to achieve all public methods in[_UnterDenLindenState]
+  ///
+  /// The only one public method is [changeBrightness],
+  /// which should be called when user would like manually change [Brightness]
+  static _UnterDenLindenState of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<_LindenUpdater>()!.data;
+
+  /// Return current instance of the [Linden].
+  /// Can be used everywhere with context (cos [UnterDenLinden] wrap everything)
+  /// The main purpose: use this method inside the `xayn_design` package
+  /// for the internal widgets.
+  static Linden getLinden(BuildContext context) => of(context)._linden;
+}
+
+class _UnterDenLindenState extends State<UnterDenLinden>
+    with WidgetsBindingObserver {
+  late Linden _linden;
+
+  /// Change [Brightness] of the current app.
+  /// If [Brightness] was changed - triggers rebuild of the whole app
+  void changeBrightness(Brightness brightness) {
+    if (brightness == _linden.brightness) return;
+
+    final style = SystemUiOverlayStyle(statusBarBrightness: brightness);
+    SystemChrome.setSystemUIOverlayStyle(style);
+
+    final newLinden = _linden.updateBrightness(brightness);
+    _updateLinden(newLinden);
+  }
+
+  @override
+  void initState() {
+    _linden = widget.initialLinden;
+    super.initState();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _updateScreenData();
+    super.didChangeMetrics();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_linden.screenSize == null) {
+      _updateScreenData();
+    }
+
+    return _LindenUpdater(
+      data: this,
+      child: widget.child,
+    );
+  }
+
+  /// Should be triggered when [Linden.screenSize] is null
+  /// or when screen params changed (rotation, resize, etc)
+  void _updateScreenData() {
+    final mediaQueryData =
+        MediaQueryData.fromWindow(WidgetsBinding.instance!.window);
+
+    ///When in landscape mode, regardless the orientation (left or right)
+    ///if there is a notch both padding.right and padding.left return
+    ///the notch padding value
+    ///If there is no notch the padding value is 0.0
+    final notchPaddingLandscapeMode = mediaQueryData.padding.right;
+
+    final newLinden = _linden.updateScreenInfo(
+      screenSize: mediaQueryData.size,
+      deviceOrientation: mediaQueryData.orientation,
+      notchPaddingLandscapeMode: notchPaddingLandscapeMode,
+    );
+    _updateLinden(newLinden);
+  }
+
+  void _updateLinden(Linden linden) {
+    if (linden == _linden) return;
+    widget.onLindenUpdated?.call(linden);
+    setState(() {
+      _linden = linden;
+    });
+  }
+}
+
+class _LindenUpdater extends InheritedWidget {
+  final _UnterDenLindenState data;
+
+  const _LindenUpdater({
+    Key? key,
+    required this.data,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  @override
+  bool updateShouldNotify(_LindenUpdater oldWidget) {
+    return true;
+  }
+}

--- a/lib/src/widget/unter_den_linden/unter_den_linden_mixin.dart
+++ b/lib/src/widget/unter_den_linden/unter_den_linden_mixin.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+/// This mixin is just for private usage inside this package.
+/// It should be used, when you need to build XAYN-related widget in respect
+/// to the current [Linden].
+///
+/// As example, please check state of [TextualNotification]
+mixin UnterDenLindenMixin<T extends StatefulWidget> on State<T> {
+  /// Should be called ONLY inside the [build] method.
+  /// If you will use it inside the builders - it might leak to the exception:
+  /// ``` Looking up a deactivated widget's ancestor is unsafe.```
+  Linden get linden => UnterDenLinden.getLinden(context);
+}

--- a/lib/xayn_design.dart
+++ b/lib/xayn_design.dart
@@ -24,5 +24,6 @@ export 'src/widget/tooltip/tooltip_controller.dart';
 export 'src/widget/tooltip/tooltip_options.dart';
 export 'src/widget/tooltip/tooltip_state_mixin.dart';
 export 'src/widget/tooltip/tooltip_stateless_mixin.dart';
+export 'src/widget/unter_den_linden/unter_den_linden.dart';
 
 export 'package:flutter_svg/flutter_svg.dart';


### PR DESCRIPTION
### What 🕵️ 🔍

- create `UnterDenLinden` widget, that is responsible for holding `Linden` and  updating the widget tree when it is changed
- create `UnterDenLindenMixin` for the internal widgets in `xayn_design`
- refactor current example app:
  - create a separate screen for `Linden`
  - create a separate screen for `Widgets`
  - add tooltip example code
- `commit-by-commit` review is possible 😉 

----------

### How to test 🥼 🔬

- [ ] run the app
- [ ] open `Linden` screen - verify that it works as before
- [ ] go back and open `Widgets` screen
- [ ] click tooltips buttons and verify that they are shown
- [ ] go back to `linden` screen and change the theme
- [ ] go back and show tooltips again - verify that the theme is changed for them as well

----------

### References 📝 🔗

- [source name](https://xainag.atlassian.net/browse/TB-2901)

----------