### PR TITLE
Add tabview to the widgets screen

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:example/screen/linden_screen.dart';
-import 'package:example/screen/widgets_screen.dart';
+import 'package:example/screen/xayn_widgets/widgets_screen.dart';
 import 'package:example/utils/tooltip_keys.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/example/lib/screen/linden_screen.dart
+++ b/example/lib/screen/linden_screen.dart
@@ -1,3 +1,4 @@
+import 'package:example/widget/toolbar.dart';
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
@@ -22,9 +23,7 @@ class _LindenScreenState extends State<LindenScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Xayn Linden'),
-      ),
+      appBar: const Toolbar(title: 'Xayn Linden'),
       body: _buildListView(),
       floatingActionButton: _buildThemeTogglerButton(),
     );

--- a/example/lib/screen/main_screen.dart
+++ b/example/lib/screen/main_screen.dart
@@ -1,5 +1,5 @@
 import 'package:example/screen/linden_screen.dart';
-import 'package:example/screen/widgets_screen.dart';
+import 'package:example/screen/xayn_widgets/widgets_screen.dart';
 import 'package:example/widget/toolbar.dart';
 import 'package:flutter/material.dart';
 
@@ -32,7 +32,7 @@ class _MainScreenState extends State<MainScreen> {
         _pushScreen(LindenScreen.routeName);
       });
 
-  Widget _buildWidgetsBtn() => _buildButton('Show widgets', () {
+  Widget _buildWidgetsBtn() => _buildButton('Show xayn widgets', () {
         _pushScreen(WidgetsScreen.routeName);
       });
 

--- a/example/lib/screen/main_screen.dart
+++ b/example/lib/screen/main_screen.dart
@@ -1,5 +1,6 @@
 import 'package:example/screen/linden_screen.dart';
 import 'package:example/screen/widgets_screen.dart';
+import 'package:example/widget/toolbar.dart';
 import 'package:flutter/material.dart';
 
 class MainScreen extends StatefulWidget {
@@ -22,7 +23,7 @@ class _MainScreenState extends State<MainScreen> {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
     );
     return Scaffold(
-      appBar: AppBar(title: const Text('Xayn Design Library')),
+      appBar: const Toolbar(title: 'Xayn Design Library'),
       body: content,
     );
   }

--- a/example/lib/screen/widgets_screen.dart
+++ b/example/lib/screen/widgets_screen.dart
@@ -1,4 +1,5 @@
 import 'package:example/utils/tooltip_keys.dart';
+import 'package:example/widget/toolbar.dart';
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
@@ -33,9 +34,7 @@ class _WidgetsScreenState extends State<WidgetsScreen> with TooltipStateMixin {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
     );
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Xayn widgets'),
-      ),
+      appBar: const Toolbar(title: 'Xayn widgets'),
       body: content,
       floatingActionButton: _buildUndoButton(),
     );

--- a/example/lib/screen/xayn_widgets/page/tooltip_page.dart
+++ b/example/lib/screen/xayn_widgets/page/tooltip_page.dart
@@ -1,47 +1,39 @@
 import 'package:example/utils/tooltip_keys.dart';
-import 'package:example/widget/toolbar.dart';
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-class WidgetsScreen extends StatefulWidget {
-  static const routeName = '/widgets';
-
-  const WidgetsScreen({
-    Key? key,
-  }) : super(key: key);
+class TooltipPage extends StatefulWidget {
+  const TooltipPage({Key? key}) : super(key: key);
 
   @override
-  State<WidgetsScreen> createState() => _WidgetsScreenState();
+  State<TooltipPage> createState() => _TooltipPageState();
 }
 
-class _WidgetsScreenState extends State<WidgetsScreen> with TooltipStateMixin {
+class _TooltipPageState extends State<TooltipPage> with TooltipStateMixin {
   Linden get linden => UnterDenLinden.getLinden(context);
 
   @override
   void initState() {
     WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
-      _registerDynamicTooltips();
+      _registerDynamicTooltips(linden);
     });
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
-    final content = Column(
+    return Column(
       children: [
         _buildSimpleTooltipBtn(),
+        _buildTooltipWithIcon(),
+        const SizedBox(height: 30),
+        _buildAnchorWidget(linden),
       ],
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
     );
-    return Scaffold(
-      appBar: const Toolbar(title: 'Xayn widgets'),
-      body: content,
-      floatingActionButton: _buildUndoButton(),
-    );
   }
 
-  void _registerDynamicTooltips() {
-    final linden = this.linden;
+  void _registerDynamicTooltips(Linden linden) {
     registerTooltip(
       key: TooltipKeys.withIcon,
       params: TooltipParams(
@@ -57,22 +49,16 @@ class _WidgetsScreenState extends State<WidgetsScreen> with TooltipStateMixin {
     );
   }
 
-  Widget _buildUndoButton() {
-    final fab = FloatingActionButton(
-      onPressed: () {
-        showTooltip(TooltipKeys.withIcon);
-      },
-      tooltip: 'Show undo',
-      child: SvgPicture.asset(
-        linden.assets.icons.undo,
-        color: linden.colors.brightIcon,
-      ),
-    );
-    return TooltipContextProvider(child: fab);
-  }
+  Widget _buildAnchorWidget(Linden linden) => TooltipContextProvider(
+      child: Text('This is tooltip anchor widget',
+          style: linden.styles.appBodyText));
 
   Widget _buildSimpleTooltipBtn() => _buildButton('Show simple tooltip', () {
         showTooltip(TooltipKeys.simple);
+      });
+
+  Widget _buildTooltipWithIcon() => _buildButton('Show tooltip with Icon', () {
+        showTooltip(TooltipKeys.withIcon);
       });
 
   Widget _buildButton(String text, VoidCallback onPressed) => Center(

--- a/example/lib/screen/xayn_widgets/widgets_screen.dart
+++ b/example/lib/screen/xayn_widgets/widgets_screen.dart
@@ -1,0 +1,60 @@
+import 'package:example/screen/xayn_widgets/page/tooltip_page.dart';
+import 'package:example/widget/toolbar.dart';
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class WidgetsScreen extends StatefulWidget {
+  static const routeName = '/widgets';
+
+  const WidgetsScreen({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<WidgetsScreen> createState() => _WidgetsScreenState();
+}
+
+class _WidgetsScreenState extends State<WidgetsScreen>
+    with TickerProviderStateMixin {
+  final tabs = <String, Widget>{
+    'Tooltip': const TooltipPage(),
+  };
+
+  late final TabController _tabController;
+
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  @override
+  void initState() {
+    _tabController = TabController(length: tabs.length, vsync: this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: Toolbar(
+          title: 'Xayn widgets',
+          bottom: _buildTabBar(),
+        ),
+        body: _buildTabBarView(),
+      );
+
+  TabBar _buildTabBar() => TabBar(
+        controller: _tabController,
+        labelStyle: linden.styles.appButtonTextInverse,
+        indicatorColor: linden.colors.primary,
+        isScrollable: true,
+        tabs: tabs.keys.toList().map((e) => Tab(child: Text(e))).toList(),
+      );
+
+  TabBarView _buildTabBarView() => TabBarView(
+        controller: _tabController,
+        children: tabs.values.toList(),
+      );
+}

--- a/example/lib/widget/toolbar.dart
+++ b/example/lib/widget/toolbar.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class Toolbar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final PreferredSizeWidget? bottom;
+
+  const Toolbar({
+    Key? key,
+    required this.title,
+    this.bottom,
+  }) : super(key: key);
+
+  @override
+  Size get preferredSize => Size(
+      double.infinity, kToolbarHeight + (bottom?.preferredSize.height ?? 0));
+
+  @override
+  Widget build(BuildContext context) {
+    final linden = UnterDenLinden.getLinden(context);
+
+    return AppBar(
+      title: Text(title),
+      bottom: bottom,
+      actions: [
+        _buildChangeThemeBtn(context, linden),
+      ],
+    );
+  }
+
+  Widget _buildChangeThemeBtn(BuildContext context, Linden linden) {
+    final isDark = linden.brightness == Brightness.dark;
+    final icon = SvgPicture.asset(
+      isDark ? linden.assets.icons.sun : linden.assets.icons.moon,
+      color: linden.colors.iconInverse,
+    );
+    return IconButton(
+      onPressed: () {
+        final brightness = isDark ? Brightness.light : Brightness.dark;
+        UnterDenLinden.of(context).changeBrightness(brightness);
+      },
+      icon: icon,
+    );
+  }
+}


### PR DESCRIPTION
### What 🕵️ 🔍

Fixes touched only example app:

- add `tabView` to the `widgetsScreen`
- move tooltips to the separate page
- create toolbar

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <img width="280" src=""> | <img width="280" src="https://user-images.githubusercontent.com/12133914/141486151-75be9203-ce96-4811-a4c1-e27f5c011065.png"> |

----------