### PR TITLE
TB-2948 settings screen widgets

### DIFF
--- a/example/lib/screen/xayn_widgets/page/settings_page.dart
+++ b/example/lib/screen/xayn_widgets/page/settings_page.dart
@@ -56,7 +56,7 @@ class _PrivacySectionState extends State<_PrivacySection> {
   bool blockCookiesEnable = true;
 
   @override
-  Widget build(BuildContext context) => SettingsSectionWidget(
+  Widget build(BuildContext context) => SettingsSection(
         title: 'Privacy settings',
         items: [
           _getBlockTrackers(),
@@ -151,7 +151,7 @@ class _AppLanguageSectionState extends State<_AppLanguageSection> {
   Linden get linden => UnterDenLinden.getLinden(context);
 
   @override
-  Widget build(BuildContext context) => SettingsSectionWidget(
+  Widget build(BuildContext context) => SettingsSection(
         title: 'Your app language',
         subTitle: 'Chose the interface language',
         items: [_getBlockTrackers()],
@@ -202,7 +202,7 @@ class _IrrelevantContentSectionState extends State<_IrrelevantContentSection> {
       _getDismissedSources(),
       _getDismissedTopics(),
     ]);
-    return SettingsSectionWidget(
+    return SettingsSection(
       title: 'Content marked as irrelevant',
       items: [cardData],
     );
@@ -260,16 +260,16 @@ class _AppThemeSectionState extends State<_AppThemeSection> {
 
   @override
   Widget build(BuildContext context) {
-    final selectable = SettingsSelectableWidget.icons(
+    final selectable = SettingsSelectable.icons(
       items: _AppTheme.values.map(_getItem).toList(),
     );
-    return SettingsSectionWidget.custom(
+    return SettingsSection.custom(
       title: 'Your app theme',
       child: selectable,
     );
   }
 
-  SettingsSelectableItem _getItem(_AppTheme theme) {
+  SettingsSelectableData _getItem(_AppTheme theme) {
     late final String title;
     late final String icon;
 
@@ -288,7 +288,7 @@ class _AppThemeSectionState extends State<_AppThemeSection> {
         break;
     }
 
-    return SettingsSelectableItem(
+    return SettingsSelectableData(
         key: Key(theme.toString()),
         title: title,
         svgIconPath: icon,
@@ -321,17 +321,17 @@ class _HomeLayoutSectionState extends State<_HomeLayoutSection> {
 
   @override
   Widget build(BuildContext context) {
-    final selectable = SettingsSelectableWidget.graphics(
+    final selectable = SettingsSelectable.graphics(
       items: _HomeLayout.values.map(_getItem).toList(),
     );
-    return SettingsSectionWidget.custom(
+    return SettingsSection.custom(
       title: 'Your Home Screen Setup',
       subTitle: 'What is displayed',
       child: selectable,
     );
   }
 
-  SettingsSelectableItem _getItem(_HomeLayout layout) {
+  SettingsSelectableData _getItem(_HomeLayout layout) {
     late final String title;
     late final String graphic;
 
@@ -350,7 +350,7 @@ class _HomeLayoutSectionState extends State<_HomeLayoutSection> {
         break;
     }
 
-    return SettingsSelectableItem(
+    return SettingsSelectableData(
         key: Key(layout.toString()),
         title: title,
         svgIconPath: graphic,
@@ -382,17 +382,17 @@ class _GridSetupSectionState extends State<_GridSetupSection> {
 
   @override
   Widget build(BuildContext context) {
-    final selectable = SettingsSelectableWidget.graphics(
+    final selectable = SettingsSelectable.graphics(
       items: _GridSetup.values.map(_getItem).toList(),
     );
-    return SettingsSectionWidget.custom(
+    return SettingsSection.custom(
       title: 'Grid setup',
       subTitle: 'How your results should be displayed',
       child: selectable,
     );
   }
 
-  SettingsSelectableItem _getItem(_GridSetup layout) {
+  SettingsSelectableData _getItem(_GridSetup layout) {
     late final String title;
     late final String graphic;
 
@@ -407,7 +407,7 @@ class _GridSetupSectionState extends State<_GridSetupSection> {
         break;
     }
 
-    return SettingsSelectableItem(
+    return SettingsSelectableData(
         key: Key(layout.toString()),
         title: title,
         svgIconPath: graphic,

--- a/example/lib/screen/xayn_widgets/page/settings_page.dart
+++ b/example/lib/screen/xayn_widgets/page/settings_page.dart
@@ -1,0 +1,421 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({Key? key}) : super(key: key);
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  bool blockTrackersEnable = true;
+  bool blockAdsEnable = true;
+
+  final List<Widget> sections = [];
+
+  @override
+  void initState() {
+    sections.addAll([
+      const _PrivacySection(),
+      const _AppLanguageSection(),
+      const _IrrelevantContentSection(),
+      const _AppThemeSection(),
+      const _HomeLayoutSection(),
+      const _GridSetupSection(),
+    ]);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => ListView.builder(
+        padding: const EdgeInsets.only(
+          left: 16,
+          right: 16,
+          bottom: 42,
+        ),
+        itemBuilder: (context, index) => sections[index],
+        itemCount: sections.length,
+      );
+}
+
+class _PrivacySection extends StatefulWidget {
+  const _PrivacySection({Key? key}) : super(key: key);
+
+  @override
+  _PrivacySectionState createState() => _PrivacySectionState();
+}
+
+class _PrivacySectionState extends State<_PrivacySection> {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  bool blockTrackersEnable = true;
+  bool blockAdsEnable = true;
+  bool blockCookiesEnable = true;
+
+  @override
+  Widget build(BuildContext context) => SettingsSectionWidget(
+        title: 'Privacy settings',
+        items: [
+          _getBlockTrackers(),
+          _getBlockAds(),
+          _getCookies(),
+          _getEmptyCache(),
+        ],
+      );
+
+  SettingsCardData _getBlockTrackers() {
+    final tile = SettingsTileData(
+      title: 'Block trackers',
+      svgIconPath: linden.assets.icons.shield,
+      action: SettingsTileActionSwitch(
+          key: const Key('Block trackers'),
+          value: blockTrackersEnable,
+          onPressed: () {
+            setState(() {
+              blockTrackersEnable = !blockTrackersEnable;
+            });
+          }),
+    );
+    return SettingsCardData.fromTile(tile);
+  }
+
+  SettingsCardData _getBlockAds() {
+    final tile = SettingsTileData(
+      title: 'Block ads',
+      svgIconPath: linden.assets.icons.shield,
+      action: SettingsTileActionSwitch(
+          key: const Key('Block ads'),
+          value: blockAdsEnable,
+          onPressed: () {
+            setState(() {
+              blockAdsEnable = !blockAdsEnable;
+            });
+          }),
+    );
+
+    return SettingsCardData.fromTile(tile);
+  }
+
+  SettingsCardData _getCookies() {
+    final blockCookies = SettingsTileData(
+      title: 'Block cookies',
+      svgIconPath: linden.assets.icons.shield,
+      action: SettingsTileActionSwitch(
+          key: const Key('Block cookies'),
+          value: blockCookiesEnable,
+          onPressed: () {
+            setState(() {
+              blockCookiesEnable = !blockCookiesEnable;
+            });
+          }),
+    );
+    final clearCookies = SettingsTileData(
+      title: 'Block cookies',
+      action: SettingsTileActionIcon(
+          key: const Key('clear cookies'),
+          svgIconPath: linden.assets.icons.trash,
+          onPressed: () {}),
+    );
+    return SettingsCardData.fromTiles([
+      blockCookies,
+      clearCookies,
+    ]);
+  }
+
+  SettingsCardData _getEmptyCache() {
+    final tile = SettingsTileData(
+      title: 'Empty cache',
+      svgIconPath: linden.assets.icons.lightening,
+      action: SettingsTileActionIcon(
+        key: const Key('Empty cache'),
+        svgIconPath: linden.assets.icons.trash,
+        onPressed: () {},
+      ),
+    );
+
+    return SettingsCardData.fromTile(tile);
+  }
+}
+
+class _AppLanguageSection extends StatefulWidget {
+  const _AppLanguageSection({Key? key}) : super(key: key);
+
+  @override
+  _AppLanguageSectionState createState() => _AppLanguageSectionState();
+}
+
+class _AppLanguageSectionState extends State<_AppLanguageSection> {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  @override
+  Widget build(BuildContext context) => SettingsSectionWidget(
+        title: 'Your app language',
+        subTitle: 'Chose the interface language',
+        items: [_getBlockTrackers()],
+      );
+
+  SettingsCardData _getBlockTrackers() {
+    final tile = SettingsTileData(
+      title: 'Active: English',
+      svgIconPath: linden.assets.icons.language,
+      action: SettingsTileActionText(
+        key: const Key('Active: English'),
+        text: 'Edit',
+        onPressed: () {},
+      ),
+    );
+    return SettingsCardData.fromTile(tile);
+  }
+}
+
+class _IrrelevantContentSection extends StatefulWidget {
+  const _IrrelevantContentSection({Key? key}) : super(key: key);
+
+  @override
+  _IrrelevantContentSectionState createState() =>
+      _IrrelevantContentSectionState();
+}
+
+class _IrrelevantContentSectionState extends State<_IrrelevantContentSection> {
+  final String topicCovid = 'Covid';
+  final String topicBlog = 'Cool people blog';
+  final String topicGodzilla = 'Godzilla';
+
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  Map<String, bool> topics = {};
+
+  @override
+  void initState() {
+    topics[topicCovid] = true;
+    topics[topicBlog] = false;
+    topics[topicGodzilla] = true;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cardData = SettingsCardData([
+      _getDismissedSources(),
+      _getDismissedTopics(),
+    ]);
+    return SettingsSectionWidget(
+      title: 'Content marked as irrelevant',
+      items: [cardData],
+    );
+  }
+
+  SettingsGroupData _getDismissedSources() {
+    final tile = SettingsTileData(
+      title: 'No dismissed items',
+      svgIconPath: linden.assets.icons.info,
+    );
+    return SettingsGroupData(title: 'Sources', items: [tile]);
+  }
+
+  SettingsGroupData _getDismissedTopics() {
+    final items = topics.keys.map(
+      (topic) {
+        final active = topics[topic] ?? false;
+        final icon =
+            active ? linden.assets.icons.minus : linden.assets.icons.plus;
+        return SettingsTileData(
+            title: topic,
+            subTitle: active ? null : 'Was just deleted from this list',
+            action: SettingsTileActionCircle(
+                key: Key(topic),
+                isActive: active,
+                svgIconPath: icon,
+                onPressed: () {
+                  setState(() {
+                    topics[topic] = !active;
+                  });
+                }));
+      },
+    ).toList();
+    return SettingsGroupData(title: 'Topics', items: items);
+  }
+}
+
+class _AppThemeSection extends StatefulWidget {
+  const _AppThemeSection({Key? key}) : super(key: key);
+
+  @override
+  _AppThemeSectionState createState() => _AppThemeSectionState();
+}
+
+enum _AppTheme {
+  system,
+  light,
+  dark,
+}
+
+class _AppThemeSectionState extends State<_AppThemeSection> {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  _AppTheme currentTheme = _AppTheme.system;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectable = SettingsSelectableWidget.icons(
+      items: _AppTheme.values.map(_getItem).toList(),
+    );
+    return SettingsSectionWidget.custom(
+      title: 'Your app theme',
+      child: selectable,
+    );
+  }
+
+  SettingsSelectableItem _getItem(_AppTheme theme) {
+    late final String title;
+    late final String icon;
+
+    switch (theme) {
+      case _AppTheme.system:
+        title = 'System default';
+        icon = linden.assets.icons.moonAndSun;
+        break;
+      case _AppTheme.light:
+        title = 'Light mode';
+        icon = linden.assets.icons.sun;
+        break;
+      case _AppTheme.dark:
+        title = 'Dark mode';
+        icon = linden.assets.icons.moon;
+        break;
+    }
+
+    return SettingsSelectableItem(
+        key: Key(theme.toString()),
+        title: title,
+        svgIconPath: icon,
+        isSelected: currentTheme == theme,
+        onPressed: () {
+          setState(() {
+            currentTheme = theme;
+          });
+        });
+  }
+}
+
+class _HomeLayoutSection extends StatefulWidget {
+  const _HomeLayoutSection({Key? key}) : super(key: key);
+
+  @override
+  _HomeLayoutSectionState createState() => _HomeLayoutSectionState();
+}
+
+enum _HomeLayout {
+  combo,
+  searchBar,
+  newsFeed,
+}
+
+class _HomeLayoutSectionState extends State<_HomeLayoutSection> {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  _HomeLayout currentLayout = _HomeLayout.combo;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectable = SettingsSelectableWidget.graphics(
+      items: _HomeLayout.values.map(_getItem).toList(),
+    );
+    return SettingsSectionWidget.custom(
+      title: 'Your Home Screen Setup',
+      subTitle: 'What is displayed',
+      child: selectable,
+    );
+  }
+
+  SettingsSelectableItem _getItem(_HomeLayout layout) {
+    late final String title;
+    late final String graphic;
+
+    switch (layout) {
+      case _HomeLayout.combo:
+        title = 'Search bar &\nNews Feed';
+        graphic = linden.assets.graphics.searchNews;
+        break;
+      case _HomeLayout.searchBar:
+        title = 'Only\nSearch Bar';
+        graphic = linden.assets.graphics.searchOnly;
+        break;
+      case _HomeLayout.newsFeed:
+        title = 'Only\nNews Feed';
+        graphic = linden.assets.graphics.newsOnly;
+        break;
+    }
+
+    return SettingsSelectableItem(
+        key: Key(layout.toString()),
+        title: title,
+        svgIconPath: graphic,
+        isSelected: currentLayout == layout,
+        onPressed: () {
+          setState(() {
+            currentLayout = layout;
+          });
+        });
+  }
+}
+
+class _GridSetupSection extends StatefulWidget {
+  const _GridSetupSection({Key? key}) : super(key: key);
+
+  @override
+  _GridSetupSectionState createState() => _GridSetupSectionState();
+}
+
+enum _GridSetup {
+  grid,
+  list,
+}
+
+class _GridSetupSectionState extends State<_GridSetupSection> {
+  Linden get linden => UnterDenLinden.getLinden(context);
+
+  _GridSetup currentSetup = _GridSetup.grid;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectable = SettingsSelectableWidget.graphics(
+      items: _GridSetup.values.map(_getItem).toList(),
+    );
+    return SettingsSectionWidget.custom(
+      title: 'Grid setup',
+      subTitle: 'How your results should be displayed',
+      child: selectable,
+    );
+  }
+
+  SettingsSelectableItem _getItem(_GridSetup layout) {
+    late final String title;
+    late final String graphic;
+
+    switch (layout) {
+      case _GridSetup.grid:
+        title = 'Grid view';
+        graphic = linden.assets.graphics.gridView;
+        break;
+      case _GridSetup.list:
+        title = 'List view';
+        graphic = linden.assets.graphics.listView;
+        break;
+    }
+
+    return SettingsSelectableItem(
+        key: Key(layout.toString()),
+        title: title,
+        svgIconPath: graphic,
+        isSelected: currentSetup == layout,
+        onPressed: () {
+          setState(() {
+            currentSetup = layout;
+          });
+        });
+  }
+}

--- a/example/lib/screen/xayn_widgets/widgets_screen.dart
+++ b/example/lib/screen/xayn_widgets/widgets_screen.dart
@@ -1,6 +1,7 @@
 import 'package:example/screen/xayn_widgets/page/button_page.dart';
 import 'package:example/screen/xayn_widgets/page/card_page.dart';
 import 'package:example/screen/xayn_widgets/page/dots_indicator_page.dart';
+import 'package:example/screen/xayn_widgets/page/settings_page.dart';
 import 'package:example/screen/xayn_widgets/page/switch_page.dart';
 import 'package:example/screen/xayn_widgets/page/tooltip_page.dart';
 import 'package:example/widget/toolbar.dart';
@@ -26,6 +27,7 @@ class _WidgetsScreenState extends State<WidgetsScreen>
     'Switch': const SwitchPage(),
     'Button': const ButtonPage(),
     'Card': const CardPage(),
+    'Settings': const SettingsPage(),
   };
 
   late final TabController _tabController;

--- a/lib/src/linden/xstyles.dart
+++ b/lib/src/linden/xstyles.dart
@@ -110,11 +110,8 @@ class XStyles {
         color: colors.tertiaryText,
       );
 
-  TextStyle? get appThumbnailTextLight => appBodyText?.copyWith(
+  TextStyle? get appThumbnailTextLight => appThumbnailText?.copyWith(
         fontWeight: _weightRegular,
-        fontSize: 10,
-        // height = 12
-        height: 1.2,
       );
 
   TextStyle? get linkText => appBodyText?.copyWith(

--- a/lib/src/widget/settings/data/settings_card_data.dart
+++ b/lib/src/widget/settings/data/settings_card_data.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+/// Item, that is displayed in [SettingsSectionWidget]
+@immutable
+class SettingsCardData {
+  final List<SettingsGroupData> items;
+
+  const SettingsCardData(this.items);
+
+  factory SettingsCardData.fromTile(SettingsTileData tile) => SettingsCardData([
+        SettingsGroupData(items: [tile])
+      ]);
+
+  factory SettingsCardData.fromTiles(List<SettingsTileData> tiles) =>
+      SettingsCardData(
+        tiles.map((tile) => SettingsGroupData(items: [tile])).toList(),
+      );
+}

--- a/lib/src/widget/settings/data/settings_card_data.dart
+++ b/lib/src/widget/settings/data/settings_card_data.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-/// Item, that is displayed in [SettingsSectionWidget]
+/// Item, that is displayed in [SettingsSection]
 @immutable
 class SettingsCardData {
   final List<SettingsGroupData> items;

--- a/lib/src/widget/settings/data/settings_group_data.dart
+++ b/lib/src/widget/settings/data/settings_group_data.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-/// Item, that is displayed in [SettingsGroupWidget]
+/// Item, that is displayed in [SettingsGroup]
 @immutable
 class SettingsGroupData {
   final String? title;

--- a/lib/src/widget/settings/data/settings_group_data.dart
+++ b/lib/src/widget/settings/data/settings_group_data.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+/// Item, that is displayed in [SettingsGroupWidget]
+@immutable
+class SettingsGroupData {
+  final String? title;
+  final List<SettingsTileData> items;
+
+  const SettingsGroupData({
+    required this.items,
+    this.title,
+  });
+}

--- a/lib/src/widget/settings/data/settings_selectable_data.dart
+++ b/lib/src/widget/settings/data/settings_selectable_data.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class SettingsSelectableItem {
+  final Key key;
+  final String title;
+  final String svgIconPath;
+  final bool isSelected;
+  final VoidCallback onPressed;
+
+  SettingsSelectableItem({
+    required this.key,
+    required this.title,
+    required this.svgIconPath,
+    required this.isSelected,
+    required this.onPressed,
+  });
+}

--- a/lib/src/widget/settings/data/settings_selectable_data.dart
+++ b/lib/src/widget/settings/data/settings_selectable_data.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
-class SettingsSelectableItem {
+class SettingsSelectableData {
   final Key key;
   final String title;
   final String svgIconPath;
   final bool isSelected;
   final VoidCallback onPressed;
 
-  SettingsSelectableItem({
+  SettingsSelectableData({
     required this.key,
     required this.title,
     required this.svgIconPath,

--- a/lib/src/widget/settings/data/settings_tile_action.dart
+++ b/lib/src/widget/settings/data/settings_tile_action.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+@immutable
+abstract class SettingsTileAction {
+  final Key key;
+  final VoidCallback onPressed;
+
+  const SettingsTileAction(this.key, this.onPressed);
+}
+
+@immutable
+class SettingsTileActionText extends SettingsTileAction {
+  final String text;
+
+  const SettingsTileActionText({
+    required this.text,
+    required VoidCallback onPressed,
+    required Key key,
+  }) : super(key, onPressed);
+}
+
+class SettingsTileActionIcon extends SettingsTileAction {
+  final String svgIconPath;
+
+  const SettingsTileActionIcon({
+    required this.svgIconPath,
+    required VoidCallback onPressed,
+    required Key key,
+  }) : super(key, onPressed);
+}
+
+class SettingsTileActionCircle extends SettingsTileAction {
+  final String svgIconPath;
+  final bool isActive;
+
+  const SettingsTileActionCircle({
+    required this.svgIconPath,
+    required this.isActive,
+    required VoidCallback onPressed,
+    required Key key,
+  }) : super(key, onPressed);
+}
+
+class SettingsTileActionSwitch extends SettingsTileAction {
+  final bool value;
+
+  const SettingsTileActionSwitch({
+    required this.value,
+    required VoidCallback onPressed,
+    required Key key,
+  }) : super(key, onPressed);
+}

--- a/lib/src/widget/settings/data/settings_tile_data.dart
+++ b/lib/src/widget/settings/data/settings_tile_data.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-/// Contain all necessary data for each individual [SettingsTileWidget]
+/// Contain all necessary data for each individual [SettingsTile]
 @immutable
 class SettingsTileData {
   final String title;

--- a/lib/src/widget/settings/data/settings_tile_data.dart
+++ b/lib/src/widget/settings/data/settings_tile_data.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+/// Contain all necessary data for each individual [SettingsTileWidget]
+@immutable
+class SettingsTileData {
+  final String title;
+  final SettingsTileAction? action;
+  final String? svgIconPath;
+  final String? subTitle;
+
+  const SettingsTileData({
+    required this.title,
+    this.action,
+    this.svgIconPath,
+    this.subTitle,
+  });
+}

--- a/lib/src/widget/settings/settings.dart
+++ b/lib/src/widget/settings/settings.dart
@@ -1,0 +1,11 @@
+export 'data/settings_card_data.dart';
+export 'data/settings_group_data.dart';
+export 'data/settings_selectable_data.dart';
+export 'data/settings_tile_action.dart';
+export 'data/settings_tile_data.dart';
+
+export 'widget/settings_card.dart';
+export 'widget/settings_group.dart';
+export 'widget/settings_section.dart';
+export 'widget/settings_selectable.dart';
+export 'widget/settings_tile.dart';

--- a/lib/src/widget/settings/widget/settings_card.dart
+++ b/lib/src/widget/settings/widget/settings_card.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class SettingsCardWidget extends StatelessWidget {
+  final SettingsCardData data;
+
+  const SettingsCardWidget({
+    Key? key,
+    required this.data,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final linden = UnterDenLinden.getLinden(context);
+
+    final children = <Widget>[];
+
+    final size = data.items.length;
+    for (int i = 0; i < size; i++) {
+      children.add(SettingsGroupWidget(data: data.items[i]));
+      if (i < size - 1) {
+        // we want to add widget after every item except the last one
+        children.add(const Divider());
+      }
+    }
+
+    final column = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+
+    final contentPadding = EdgeInsets.fromLTRB(
+      linden.dimen.unit2,
+      linden.dimen.unit,
+      linden.dimen.unit,
+      linden.dimen.unit,
+    );
+
+    return AppCardWidget(
+      elevation: linden.dimen.elevationHigh,
+      child: column,
+      contentPadding: contentPadding,
+    );
+  }
+}

--- a/lib/src/widget/settings/widget/settings_card.dart
+++ b/lib/src/widget/settings/widget/settings_card.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-class SettingsCardWidget extends StatelessWidget {
+class SettingsCard extends StatelessWidget {
   final SettingsCardData data;
 
-  const SettingsCardWidget({
+  const SettingsCard({
     Key? key,
     required this.data,
   }) : super(key: key);
@@ -17,7 +17,7 @@ class SettingsCardWidget extends StatelessWidget {
 
     final size = data.items.length;
     for (int i = 0; i < size; i++) {
-      children.add(SettingsGroupWidget(data: data.items[i]));
+      children.add(SettingsGroup(data: data.items[i]));
       if (i < size - 1) {
         // we want to add widget after every item except the last one
         children.add(const Divider());

--- a/lib/src/widget/settings/widget/settings_group.dart
+++ b/lib/src/widget/settings/widget/settings_group.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class SettingsGroupWidget extends StatelessWidget {
+  final SettingsGroupData data;
+
+  const SettingsGroupWidget({
+    Key? key,
+    required this.data,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final linden = UnterDenLinden.getLinden(context);
+    final children = <Widget>[];
+
+    _addTitle(context, children, linden);
+
+    final size = data.items.length;
+    for (int i = 0; i < size; i++) {
+      children.add(SettingsTileWidget(data: data.items[i]));
+      if (i < size - 1) {
+        // we want to add widget after every item except the last one
+        children.add(SizedBox(height: linden.dimen.unit2));
+      }
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+  }
+
+  void _addTitle(
+    BuildContext context,
+    List<Widget> children,
+    Linden linden,
+  ) {
+    final title = data.title;
+    if (title == null) return;
+
+    final padding = Padding(
+      padding: EdgeInsets.symmetric(vertical: linden.dimen.unit),
+      child: Text(title, style: linden.styles.settingsLayoutSectionText),
+    );
+    children.add(padding);
+  }
+}

--- a/lib/src/widget/settings/widget/settings_group.dart
+++ b/lib/src/widget/settings/widget/settings_group.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-class SettingsGroupWidget extends StatelessWidget {
+class SettingsGroup extends StatelessWidget {
   final SettingsGroupData data;
 
-  const SettingsGroupWidget({
+  const SettingsGroup({
     Key? key,
     required this.data,
   }) : super(key: key);
@@ -18,7 +18,7 @@ class SettingsGroupWidget extends StatelessWidget {
 
     final size = data.items.length;
     for (int i = 0; i < size; i++) {
-      children.add(SettingsTileWidget(data: data.items[i]));
+      children.add(SettingsTile(data: data.items[i]));
       if (i < size - 1) {
         // we want to add widget after every item except the last one
         children.add(SizedBox(height: linden.dimen.unit2));

--- a/lib/src/widget/settings/widget/settings_section.dart
+++ b/lib/src/widget/settings/widget/settings_section.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-class SettingsSectionWidget extends StatelessWidget {
+class SettingsSection extends StatelessWidget {
   final String title;
   final String? subTitle;
   final List<SettingsCardData> items;
   final Widget? _child;
 
-  const SettingsSectionWidget({
+  const SettingsSection({
     Key? key,
     required this.title,
     required this.items,
@@ -16,7 +16,7 @@ class SettingsSectionWidget extends StatelessWidget {
         _child = null,
         super(key: key);
 
-  SettingsSectionWidget.fromTile({
+  SettingsSection.fromTile({
     Key? key,
     required this.title,
     required SettingsTileData tileData,
@@ -29,8 +29,8 @@ class SettingsSectionWidget extends StatelessWidget {
         _child = null,
         super(key: key);
 
-  /// So far used to show [SettingsSelectableWidget]
-  SettingsSectionWidget.custom({
+  /// So far used to show [SettingsSelectable]
+  SettingsSection.custom({
     Key? key,
     required this.title,
     required Widget child,
@@ -62,7 +62,7 @@ class SettingsSectionWidget extends StatelessWidget {
     } else {
       final size = items.length;
       for (int i = 0; i < size; i++) {
-        final card = SettingsCardWidget(data: SettingsCardData(items[i].items));
+        final card = SettingsCard(data: SettingsCardData(items[i].items));
         columnChildren.add(card);
         if (i < size - 1) {
           // we want to add widget after every item except the last one

--- a/lib/src/widget/settings/widget/settings_section.dart
+++ b/lib/src/widget/settings/widget/settings_section.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class SettingsSectionWidget extends StatelessWidget {
+  final String title;
+  final String? subTitle;
+  final List<SettingsCardData> items;
+  final Widget? _child;
+
+  const SettingsSectionWidget({
+    Key? key,
+    required this.title,
+    required this.items,
+    this.subTitle,
+  })  : assert(items.length > 0),
+        _child = null,
+        super(key: key);
+
+  SettingsSectionWidget.fromTile({
+    Key? key,
+    required this.title,
+    required SettingsTileData tileData,
+    this.subTitle,
+  })  : items = [
+          SettingsCardData([
+            SettingsGroupData(items: [tileData])
+          ])
+        ],
+        _child = null,
+        super(key: key);
+
+  /// So far used to show [SettingsSelectableWidget]
+  SettingsSectionWidget.custom({
+    Key? key,
+    required this.title,
+    required Widget child,
+    this.subTitle,
+  })  : items = [const SettingsCardData([])],
+        _child = child,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final linden = UnterDenLinden.getLinden(context);
+
+    final columnChildren = <Widget>[
+      SizedBox(height: linden.dimen.unit4),
+      _buildTitle(linden),
+    ];
+
+    final subTitle = _buildSubTitle(linden);
+    if (subTitle != null) {
+      columnChildren
+        ..add(SizedBox(height: linden.dimen.unit))
+        ..add(subTitle);
+    }
+
+    columnChildren.add(SizedBox(height: linden.dimen.unit2));
+
+    if (_child != null) {
+      columnChildren.add(_child!);
+    } else {
+      final size = items.length;
+      for (int i = 0; i < size; i++) {
+        final card = SettingsCardWidget(data: SettingsCardData(items[i].items));
+        columnChildren.add(card);
+        if (i < size - 1) {
+          // we want to add widget after every item except the last one
+          columnChildren.add(SizedBox(height: linden.dimen.unit));
+        }
+      }
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: columnChildren,
+    );
+  }
+
+  Widget _buildTitle(Linden linden) => Text(
+        title,
+        style: linden.styles.appHeadlineText,
+      );
+
+  Widget? _buildSubTitle(Linden linden) => subTitle == null
+      ? null
+      : Text(
+          subTitle!,
+          style: linden.styles.appBodyText,
+        );
+}

--- a/lib/src/widget/settings/widget/settings_selectable.dart
+++ b/lib/src/widget/settings/widget/settings_selectable.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+enum SettingsSelectable {
+  icon,
+  graphic,
+}
+
+class SettingsSelectableWidget extends StatelessWidget {
+  final List<SettingsSelectableItem> items;
+  final SettingsSelectable type;
+
+  const SettingsSelectableWidget.icons({
+    Key? key,
+    required this.items,
+  })  : type = SettingsSelectable.icon,
+        super(key: key);
+
+  const SettingsSelectableWidget.graphics({
+    Key? key,
+    required this.items,
+  })  : type = SettingsSelectable.graphic,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) => AppCardWidget(
+        child: LayoutBuilder(builder: _buildGroup),
+        contentPadding: EdgeInsets.zero,
+      );
+
+  Widget _buildGroup(BuildContext context, BoxConstraints constraints) {
+    final linden = UnterDenLinden.getLinden(context);
+
+    final itemConstrains =
+        BoxConstraints(minWidth: constraints.maxWidth / items.length);
+
+    switch (type) {
+      case SettingsSelectable.icon:
+        return _buildIconGroup(itemConstrains, linden);
+      case SettingsSelectable.graphic:
+        return _buildGraphicGroup(itemConstrains, linden);
+    }
+  }
+
+  Widget _buildIconGroup(BoxConstraints itemConstraints, Linden linden) =>
+      ToggleButtons(
+        fillColor: linden.colors.accent,
+        renderBorder: false,
+        constraints: itemConstraints,
+        isSelected: items.map((e) => e.isSelected).toList(),
+        children: items.map((e) => _buildIconItem(e, linden)).toList(),
+        onPressed: (int index) {
+          items[index].onPressed();
+        },
+      );
+
+  Widget _buildGraphicGroup(BoxConstraints itemConstraints, Linden linden) {
+    final children = items
+        .map((e) => _buildGraphicIcon(e, itemConstraints, linden))
+        .toList();
+    return Row(
+      children: children,
+    );
+  }
+
+  Widget _buildGraphicIcon(
+    SettingsSelectableItem item,
+    BoxConstraints itemConstraints,
+    Linden linden,
+  ) {
+    final radioBtn = Radio<SettingsSelectableItem>(
+      key: item.key,
+      value: item,
+      groupValue: item.isSelected ? item : null,
+      onChanged: (_) => item.onPressed(),
+      activeColor: linden.colors.accent,
+    );
+    final graphic = Container(
+      constraints: BoxConstraints(
+        maxHeight: linden.dimen.graphicsHeight,
+        maxWidth: linden.dimen.graphicsGridViewWidth,
+      ),
+      decoration: BoxDecoration(
+        shape: BoxShape.rectangle,
+        color: item.isSelected
+            ? linden.colors.iconSelected
+            : linden.colors.iconDisabled,
+        borderRadius: linden.styles.roundBorder0_5,
+      ),
+      child: SvgPicture.asset(item.svgIconPath),
+    );
+
+    final title = Text(
+      item.title,
+      textAlign: TextAlign.center,
+      style: linden.styles.settingsLayoutSectionText,
+    );
+    final children = <Widget>[
+      radioBtn,
+      graphic,
+      SizedBox(height: linden.dimen.unit1_5),
+      title,
+      SizedBox(height: linden.dimen.unit2),
+    ];
+
+    return InkWell(
+      key: item.key,
+      onTap: item.onPressed,
+      child: Container(
+        constraints: itemConstraints,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: children,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIconItem(SettingsSelectableItem item, Linden linden) {
+    final icon = SvgPicture.asset(
+      item.svgIconPath,
+      width: linden.dimen.iconSize,
+      height: linden.dimen.iconSize,
+      color: item.isSelected ? linden.colors.accent : linden.colors.primary,
+    );
+
+    final withCircle = Container(
+      child: Center(child: icon),
+      decoration: BoxDecoration(
+        color: item.isSelected
+            ? linden.colors.iconBackgroundSelected
+            : linden.colors.iconBackground,
+        shape: BoxShape.circle,
+      ),
+      width: linden.dimen.unit5,
+      height: linden.dimen.unit5,
+    );
+
+    final isDarkMode = linden.brightness == Brightness.dark;
+    final title = Text(
+      item.title,
+      textAlign: TextAlign.center,
+      style: item.isSelected && !isDarkMode
+          ? linden.styles.settingsLayoutSectionTextSelected
+          : linden.styles.settingsLayoutSectionText,
+    );
+
+    final column = Column(
+      children: [
+        withCircle,
+        SizedBox(height: linden.dimen.unit1_5),
+        title,
+      ],
+      mainAxisSize: MainAxisSize.min,
+    );
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: linden.dimen.unit2),
+      child: column,
+    );
+  }
+}

--- a/lib/src/widget/settings/widget/settings_selectable.dart
+++ b/lib/src/widget/settings/widget/settings_selectable.dart
@@ -1,25 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-enum SettingsSelectable {
+enum SettingsSelectableType {
   icon,
   graphic,
 }
 
-class SettingsSelectableWidget extends StatelessWidget {
-  final List<SettingsSelectableItem> items;
-  final SettingsSelectable type;
+class SettingsSelectable extends StatelessWidget {
+  final List<SettingsSelectableData> items;
+  final SettingsSelectableType type;
 
-  const SettingsSelectableWidget.icons({
+  const SettingsSelectable.icons({
     Key? key,
     required this.items,
-  })  : type = SettingsSelectable.icon,
+  })  : type = SettingsSelectableType.icon,
         super(key: key);
 
-  const SettingsSelectableWidget.graphics({
+  const SettingsSelectable.graphics({
     Key? key,
     required this.items,
-  })  : type = SettingsSelectable.graphic,
+  })  : type = SettingsSelectableType.graphic,
         super(key: key);
 
   @override
@@ -35,9 +35,9 @@ class SettingsSelectableWidget extends StatelessWidget {
         BoxConstraints(minWidth: constraints.maxWidth / items.length);
 
     switch (type) {
-      case SettingsSelectable.icon:
+      case SettingsSelectableType.icon:
         return _buildIconGroup(itemConstrains, linden);
-      case SettingsSelectable.graphic:
+      case SettingsSelectableType.graphic:
         return _buildGraphicGroup(itemConstrains, linden);
     }
   }
@@ -64,11 +64,11 @@ class SettingsSelectableWidget extends StatelessWidget {
   }
 
   Widget _buildGraphicIcon(
-    SettingsSelectableItem item,
+    SettingsSelectableData item,
     BoxConstraints itemConstraints,
     Linden linden,
   ) {
-    final radioBtn = Radio<SettingsSelectableItem>(
+    final radioBtn = Radio<SettingsSelectableData>(
       key: item.key,
       value: item,
       groupValue: item.isSelected ? item : null,
@@ -116,7 +116,7 @@ class SettingsSelectableWidget extends StatelessWidget {
     );
   }
 
-  Widget _buildIconItem(SettingsSelectableItem item, Linden linden) {
+  Widget _buildIconItem(SettingsSelectableData item, Linden linden) {
     final icon = SvgPicture.asset(
       item.svgIconPath,
       width: linden.dimen.iconSize,

--- a/lib/src/widget/settings/widget/settings_tile.dart
+++ b/lib/src/widget/settings/widget/settings_tile.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+class SettingsTileWidget extends StatelessWidget {
+  final SettingsTileData data;
+
+  const SettingsTileWidget({
+    Key? key,
+    required this.data,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final rowChildren = <Widget>[];
+
+    final linden = UnterDenLinden.getLinden(context);
+
+    _addIcon(linden, rowChildren);
+    _addText(linden, rowChildren);
+    rowChildren.add(const Spacer());
+    _addAction(linden, rowChildren);
+
+    final row = Row(
+      children: rowChildren,
+      crossAxisAlignment: CrossAxisAlignment.start,
+    );
+    return SizedBox(height: linden.dimen.unit5, child: row);
+  }
+
+  void _addIcon(Linden linden, List<Widget> rowChildren) {
+    final iconPath = data.svgIconPath;
+    if (iconPath == null) return;
+
+    final iconSize = linden.dimen.unit3;
+    final icon = SvgPicture.asset(
+      iconPath,
+      color: linden.colors.primary,
+      width: iconSize,
+      height: iconSize,
+    );
+
+    final withPadding = Padding(
+      padding: EdgeInsets.only(right: linden.dimen.unit2),
+      child: icon,
+    );
+    rowChildren.add(Center(child: withPadding));
+  }
+
+  void _addText(
+    Linden linden,
+    List<Widget> rowChildren,
+  ) {
+    void addChild(Widget child) => rowChildren.add(Center(child: child));
+
+    final title = Text(data.title, style: linden.styles.appBodyText);
+
+    if (data.subTitle == null) {
+      addChild(title);
+      return;
+    }
+
+    final subTitle = Text(
+      data.subTitle!,
+      style: linden.styles.appThumbnailTextLight,
+    );
+
+    final column = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        title,
+        SizedBox(height: linden.dimen.unit0_5),
+        subTitle,
+      ],
+    );
+    addChild(column);
+  }
+
+  void _addAction(Linden linden, List<Widget> rowChildren) {
+    final action = data.action;
+    if (action == null) return;
+    late final Widget child;
+    switch (action.runtimeType) {
+      case SettingsTileActionText:
+        child = _buildActionText(action as SettingsTileActionText);
+        break;
+      case SettingsTileActionIcon:
+        child = _buildActionIcon(action as SettingsTileActionIcon);
+        break;
+      case SettingsTileActionCircle:
+        child = _buildActionCircle(action as SettingsTileActionCircle, linden);
+        break;
+      case SettingsTileActionSwitch:
+        child = _buildActionSwitch(action as SettingsTileActionSwitch);
+        break;
+      default:
+        throw Exception(
+            'Unknown instance of $SettingsTileActionText: ${action.runtimeType}');
+    }
+
+    final withPadding = Padding(
+      padding: EdgeInsets.only(left: linden.dimen.unit2),
+      child: Center(child: child),
+    );
+    rowChildren.add(withPadding);
+  }
+
+  Widget _buildActionText(SettingsTileActionText action) =>
+      AppRaisedButton.text(
+        onPressed: action.onPressed,
+        text: action.text,
+        key: action.key,
+        minSizeEqual: true,
+      );
+
+  Widget _buildActionIcon(SettingsTileActionIcon action) =>
+      AppRaisedButton.icon(
+        key: action.key,
+        svgIconPath: action.svgIconPath,
+        onPressed: action.onPressed,
+      );
+
+  Widget _buildActionCircle(SettingsTileActionCircle action, Linden linden) {
+    final btn = AppRaisedButton.icon(
+      key: action.key,
+      svgIconPath: action.svgIconPath,
+      onPressed: action.onPressed,
+      contentPadding: EdgeInsets.all(linden.dimen.unit0_5),
+      color: action.isActive ? ButtonColor.primary : ButtonColor.tertiary,
+      circle: true,
+    );
+    return SizedBox(
+      height: linden.dimen.unit3,
+      child: Center(child: btn),
+    );
+  }
+
+  Widget _buildActionSwitch(SettingsTileActionSwitch action) => AppSwitchWidget(
+        key: action.key,
+        value: action.value,
+        onToggle: (_) => action.onPressed(),
+      );
+}

--- a/lib/src/widget/settings/widget/settings_tile.dart
+++ b/lib/src/widget/settings/widget/settings_tile.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
 
-class SettingsTileWidget extends StatelessWidget {
+class SettingsTile extends StatelessWidget {
   final SettingsTileData data;
 
-  const SettingsTileWidget({
+  const SettingsTile({
     Key? key,
     required this.data,
   }) : super(key: key);

--- a/lib/xayn_design.dart
+++ b/lib/xayn_design.dart
@@ -20,6 +20,7 @@ export 'src/widget/button/app_raised_button.dart';
 export 'src/widget/card/app_card.dart';
 export 'src/widget/dots_indicator/dots_decorator.dart';
 export 'src/widget/dots_indicator/dots_indicator.dart';
+export 'src/widget/settings/settings.dart';
 export 'src/widget/switch/app_switch.dart';
 export 'src/widget/tooltip/application_tooltip_provider.dart';
 export 'src/widget/tooltip/messages/textual_notification.dart';


### PR DESCRIPTION
### What 🕵️ 🔍

- create a list of settings-related widgets and data-models for them
- create a page in the example app with the settings-related widgets
- documentation and widget tests will be provided within the separate PR

----------

### How to test 🥼 🔬

- run the app
- compare figma-design with the cases displayed in the example app

----------

### Screenshots 📸 📱

| light | dark  |
| ------ | ------ |
| <img width="280" src="https://user-images.githubusercontent.com/12133914/142187785-b841fe32-9d79-4702-87d1-9a960aa8c5a8.png"> | <img width="280" src="https://user-images.githubusercontent.com/12133914/142187790-c2dc6c77-e95f-4717-a402-1952de5aaa8e.png"> |
| <img width="280" src="https://user-images.githubusercontent.com/12133914/142188096-0d6adf2c-de07-41b2-89a0-eed658b35793.png"> | <img width="280" src="https://user-images.githubusercontent.com/12133914/142187972-4c5c1c7b-326a-4b1f-bb5a-6a1d579d1c24.png"> |
| <img width="280" src="https://user-images.githubusercontent.com/12133914/142188162-af2d1e27-7581-4b2a-9ddf-11c31a3ab8f9.png"> | <img width="280" src="https://user-images.githubusercontent.com/12133914/142188175-272aff22-c1bc-4b35-9e7a-d494d68d76b8.png"> |

<img width="600" src="https://user-images.githubusercontent.com/12133914/142233111-68f8e467-55c7-42e5-8397-898c85dd1876.png">

----------


### References 📝 🔗

- [source name](https://xainag.atlassian.net/browse/TB-2948)
- [Figma](https://www.figma.com/file/8pOuL775gZljslS6b6nfJ5/Search-App-Design-%7C-Xayn?node-id=7564%3A9246)

----------