### PR TITLE
Nav_bar refactoring

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:example/screen/linden_screen.dart';
 import 'package:example/screen/main_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_account_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_home_screen.dart';
+import 'package:example/screen/nav_bar/nav_bar_ignored_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_onboarding_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_reader_node_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_search_screen.dart';
@@ -100,6 +101,9 @@ class MyApp extends StatelessWidget {
         break;
       case NavBarReaderModeScreen.routeName:
         screenWidget = const NavBarReaderModeScreen();
+        break;
+      case NavBarIgnoredScreen.routeName:
+        screenWidget = const NavBarIgnoredScreen();
         break;
       default:
         screenWidget = null;

--- a/example/lib/screen/nav_bar/base_nav_bar_screen.dart
+++ b/example/lib/screen/nav_bar/base_nav_bar_screen.dart
@@ -1,5 +1,6 @@
 import 'package:example/screen/nav_bar/nav_bar_account_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_home_screen.dart';
+import 'package:example/screen/nav_bar/nav_bar_ignored_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_onboarding_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_reader_node_screen.dart';
 import 'package:example/screen/nav_bar/nav_bar_search_screen.dart';
@@ -73,6 +74,8 @@ abstract class BaseNavBarScreenState<T extends BaseNavBarScreen>
   void openReaderMode() => _push(NavBarReaderModeScreen.routeName);
 
   void openOnboarding() => _push(NavBarOnboardingScreen.routeName);
+
+  void openIgnored() => _push(NavBarIgnoredScreen.routeName);
 
   Widget buildBtn(String title, VoidCallback onPressed) =>
       AppRaisedButton.text(onPressed: onPressed, text: title);

--- a/example/lib/screen/nav_bar/nav_bar_account_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_account_screen.dart
@@ -26,7 +26,7 @@ class _NavBarHomeScreenState extends BaseNavBarScreenState<NavBarAccountScreen>
       ];
 
   @override
-  NavBarConfig get navBarConfig => NavBarConfig([
+  NavBarConfig? get navBarConfig => NavBarConfig([
         itemHome(),
         itemSearch(),
         itemAccount(isCurrent: true),

--- a/example/lib/screen/nav_bar/nav_bar_account_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_account_screen.dart
@@ -9,10 +9,10 @@ class NavBarAccountScreen extends BaseNavBarScreen {
   const NavBarAccountScreen({Key? key}) : super(key: key);
 
   @override
-  _NavBarHomeScreenState createState() => _NavBarHomeScreenState();
+  _NavBarAccountScreenState createState() => _NavBarAccountScreenState();
 }
 
-class _NavBarHomeScreenState extends BaseNavBarScreenState<NavBarAccountScreen>
+class _NavBarAccountScreenState extends BaseNavBarScreenState<NavBarAccountScreen>
     with NavBarConfigMixin {
   @override
   String get screenTitle => 'Account screen';

--- a/example/lib/screen/nav_bar/nav_bar_account_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_account_screen.dart
@@ -26,7 +26,7 @@ class _NavBarAccountScreenState extends BaseNavBarScreenState<NavBarAccountScree
       ];
 
   @override
-  NavBarConfig? get navBarConfig => NavBarConfig([
+  NavBarConfig get navBarConfig => NavBarConfig([
         itemHome(),
         itemSearch(),
         itemAccount(isCurrent: true),

--- a/example/lib/screen/nav_bar/nav_bar_home_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_home_screen.dart
@@ -28,7 +28,7 @@ class _NavBarHomeScreenState extends BaseNavBarScreenState<NavBarHomeScreen>
       ];
 
   @override
-  NavBarConfig? get navBarConfig => NavBarConfig([
+  NavBarConfig get navBarConfig => NavBarConfig([
         itemHome(isCurrent: true),
         itemSearch(),
         itemAccount(),

--- a/example/lib/screen/nav_bar/nav_bar_home_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_home_screen.dart
@@ -24,10 +24,11 @@ class _NavBarHomeScreenState extends BaseNavBarScreenState<NavBarHomeScreen>
   List<Widget> buildExtraChildren() => [
         buildBtn('Open reader mode', openReaderMode),
         buildBtn('Open onboarding screen', openOnboarding),
+        buildBtn('Open ignored screen', openIgnored),
       ];
 
   @override
-  NavBarConfig get navBarConfig => NavBarConfig([
+  NavBarConfig? get navBarConfig => NavBarConfig([
         itemHome(isCurrent: true),
         itemSearch(),
         itemAccount(),

--- a/example/lib/screen/nav_bar/nav_bar_ignored_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_ignored_screen.dart
@@ -53,8 +53,8 @@ class _NavBarIgnoredScreenState
   }
 
   @override
-  NavBarConfig? get navBarConfig => isIgnored
-      ? null
+  NavBarConfig get navBarConfig => isIgnored
+      ? NavBarConfig.ignored()
       : NavBarConfig.backBtn(NavBarItemBackButton(
           onPressed: () {
             Navigator.of(context).pop();

--- a/example/lib/screen/nav_bar/nav_bar_ignored_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_ignored_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+
+import 'base_nav_bar_screen.dart';
+
+class NavBarIgnoredScreen extends BaseNavBarScreen {
+  static const routeName = '/navBarIgnoredScreen';
+
+  const NavBarIgnoredScreen({Key? key}) : super(key: key);
+
+  @override
+  _NavBarIgnoredScreenState createState() => _NavBarIgnoredScreenState();
+}
+
+class _NavBarIgnoredScreenState
+    extends BaseNavBarScreenState<NavBarIgnoredScreen> with NavBarConfigMixin {
+  @override
+  String get screenTitle => 'Ignored screen';
+
+  @override
+  Color get screenBgColor => Colors.blue;
+
+  bool isIgnored = true;
+
+  @override
+  List<Widget> buildExtraChildren() {
+    final title = Text(
+      'At this screen configs CAN BE ignored and then previous [$NavBarConfig] will be applied',
+      textAlign: TextAlign.center,
+    );
+    final row = Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text('Ignore current screen config'),
+        const SizedBox(width: 42),
+        AppSwitchWidget(
+            value: isIgnored,
+            onToggle: (isIgnored) {
+              setState(
+                () {
+                  this.isIgnored = isIgnored;
+                  NavBarContainer.updateNavBar(context);
+                },
+              );
+            })
+      ],
+    );
+    return [
+      title,
+      const SizedBox(height: 42),
+      row,
+    ];
+  }
+
+  @override
+  NavBarConfig? get navBarConfig => isIgnored
+      ? null
+      : NavBarConfig.backBtn(NavBarItemBackButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          key: back,
+        ));
+}

--- a/example/lib/screen/nav_bar/nav_bar_onboarding_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_onboarding_screen.dart
@@ -12,7 +12,8 @@ class NavBarOnboardingScreen extends BaseNavBarScreen {
   _NavBarOnboardingScreenState createState() => _NavBarOnboardingScreenState();
 }
 
-class _NavBarOnboardingScreenState extends BaseNavBarScreenState<NavBarOnboardingScreen>
+class _NavBarOnboardingScreenState
+    extends BaseNavBarScreenState<NavBarOnboardingScreen>
     with NavBarConfigMixin {
   @override
   String get screenTitle => 'Onboarding screen';
@@ -21,7 +22,7 @@ class _NavBarOnboardingScreenState extends BaseNavBarScreenState<NavBarOnboardin
   Color get screenBgColor => Colors.blue;
 
   @override
-  NavBarConfig? get navBarConfig => NavBarConfig.hidden();
+  NavBarConfig get navBarConfig => NavBarConfig.hidden();
 
   @override
   List<Widget> buildExtraChildren() => [

--- a/example/lib/screen/nav_bar/nav_bar_onboarding_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_onboarding_screen.dart
@@ -9,10 +9,10 @@ class NavBarOnboardingScreen extends BaseNavBarScreen {
   const NavBarOnboardingScreen({Key? key}) : super(key: key);
 
   @override
-  _NavBarScreenState createState() => _NavBarScreenState();
+  _NavBarOnboardingScreenState createState() => _NavBarOnboardingScreenState();
 }
 
-class _NavBarScreenState extends BaseNavBarScreenState<NavBarOnboardingScreen>
+class _NavBarOnboardingScreenState extends BaseNavBarScreenState<NavBarOnboardingScreen>
     with NavBarConfigMixin {
   @override
   String get screenTitle => 'Onboarding screen';

--- a/example/lib/screen/nav_bar/nav_bar_onboarding_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_onboarding_screen.dart
@@ -21,7 +21,7 @@ class _NavBarScreenState extends BaseNavBarScreenState<NavBarOnboardingScreen>
   Color get screenBgColor => Colors.blue;
 
   @override
-  NavBarConfig get navBarConfig => NavBarConfig.hide();
+  NavBarConfig? get navBarConfig => NavBarConfig.hidden();
 
   @override
   List<Widget> buildExtraChildren() => [

--- a/example/lib/screen/nav_bar/nav_bar_reader_node_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_reader_node_screen.dart
@@ -24,7 +24,7 @@ class _NavBarReaderModeScreenState
   bool? isLiked;
 
   @override
-  NavBarConfig? get navBarConfig {
+  NavBarConfig get navBarConfig {
     final goBack = NavBarItemIconButton(
       svgIconPath: linden.assets.icons.arrowLeft,
       isHighlighted: false,

--- a/example/lib/screen/nav_bar/nav_bar_reader_node_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_reader_node_screen.dart
@@ -9,10 +9,10 @@ class NavBarReaderModeScreen extends BaseNavBarScreen {
   const NavBarReaderModeScreen({Key? key}) : super(key: key);
 
   @override
-  _NavBarHomeScreenState createState() => _NavBarHomeScreenState();
+  _NavBarReaderModeScreenState createState() => _NavBarReaderModeScreenState();
 }
 
-class _NavBarHomeScreenState
+class _NavBarReaderModeScreenState
     extends BaseNavBarScreenState<NavBarReaderModeScreen>
     with NavBarConfigMixin {
   @override

--- a/example/lib/screen/nav_bar/nav_bar_reader_node_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_reader_node_screen.dart
@@ -24,7 +24,7 @@ class _NavBarHomeScreenState
   bool? isLiked;
 
   @override
-  NavBarConfig get navBarConfig {
+  NavBarConfig? get navBarConfig {
     final goBack = NavBarItemIconButton(
       svgIconPath: linden.assets.icons.arrowLeft,
       isHighlighted: false,

--- a/example/lib/screen/nav_bar/nav_bar_search_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_search_screen.dart
@@ -23,7 +23,7 @@ class _NavBarSearchScreenState extends BaseNavBarScreenState<NavBarSearchScreen>
   Color get screenBgColor => Colors.greenAccent;
 
   @override
-  NavBarConfig? get navBarConfig {
+  NavBarConfig get navBarConfig {
     final search = NavBarItemEdit(
       svgIconPath: linden.assets.icons.search,
       isHighlighted: true,

--- a/example/lib/screen/nav_bar/nav_bar_search_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_search_screen.dart
@@ -11,10 +11,10 @@ class NavBarSearchScreen extends BaseNavBarScreen {
   const NavBarSearchScreen({Key? key}) : super(key: key);
 
   @override
-  _NavBarScreenState createState() => _NavBarScreenState();
+  _NavBarSearchScreenState createState() => _NavBarSearchScreenState();
 }
 
-class _NavBarScreenState extends BaseNavBarScreenState<NavBarSearchScreen>
+class _NavBarSearchScreenState extends BaseNavBarScreenState<NavBarSearchScreen>
     with NavBarConfigMixin {
   @override
   String get screenTitle => 'Search screen';

--- a/example/lib/screen/nav_bar/nav_bar_search_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_search_screen.dart
@@ -23,7 +23,7 @@ class _NavBarScreenState extends BaseNavBarScreenState<NavBarSearchScreen>
   Color get screenBgColor => Colors.greenAccent;
 
   @override
-  NavBarConfig get navBarConfig {
+  NavBarConfig? get navBarConfig {
     final search = NavBarItemEdit(
       svgIconPath: linden.assets.icons.search,
       isHighlighted: true,

--- a/example/lib/screen/nav_bar/nav_bar_settings_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_settings_screen.dart
@@ -9,10 +9,10 @@ class NavBarSettingsScreen extends BaseNavBarScreen {
   const NavBarSettingsScreen({Key? key}) : super(key: key);
 
   @override
-  _NavBarScreenState createState() => _NavBarScreenState();
+  _NavBarSettingsScreenState createState() => _NavBarSettingsScreenState();
 }
 
-class _NavBarScreenState extends BaseNavBarScreenState<NavBarSettingsScreen>
+class _NavBarSettingsScreenState extends BaseNavBarScreenState<NavBarSettingsScreen>
     with NavBarConfigMixin {
   @override
   String get screenTitle => 'Settings screen';

--- a/example/lib/screen/nav_bar/nav_bar_settings_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_settings_screen.dart
@@ -12,8 +12,8 @@ class NavBarSettingsScreen extends BaseNavBarScreen {
   _NavBarSettingsScreenState createState() => _NavBarSettingsScreenState();
 }
 
-class _NavBarSettingsScreenState extends BaseNavBarScreenState<NavBarSettingsScreen>
-    with NavBarConfigMixin {
+class _NavBarSettingsScreenState
+    extends BaseNavBarScreenState<NavBarSettingsScreen> with NavBarConfigMixin {
   @override
   String get screenTitle => 'Settings screen';
 
@@ -21,7 +21,7 @@ class _NavBarSettingsScreenState extends BaseNavBarScreenState<NavBarSettingsScr
   Color get screenBgColor => Colors.blue;
 
   @override
-  NavBarConfig? get navBarConfig {
+  NavBarConfig get navBarConfig {
     final item = NavBarItemBackButton(
       onPressed: () {
         Navigator.of(context).pop();

--- a/example/lib/screen/nav_bar/nav_bar_settings_screen.dart
+++ b/example/lib/screen/nav_bar/nav_bar_settings_screen.dart
@@ -21,7 +21,7 @@ class _NavBarScreenState extends BaseNavBarScreenState<NavBarSettingsScreen>
   Color get screenBgColor => Colors.blue;
 
   @override
-  NavBarConfig get navBarConfig {
+  NavBarConfig? get navBarConfig {
     final item = NavBarItemBackButton(
       onPressed: () {
         Navigator.of(context).pop();

--- a/lib/src/widget/nav_bar/data/config_pair.dart
+++ b/lib/src/widget/nav_bar/data/config_pair.dart
@@ -4,13 +4,16 @@ import 'package:xayn_design/src/widget/nav_bar/widget/nav_bar.dart';
 
 class ConfigPair extends Equatable {
   final ConfigUpdater updater;
-  final NavBarConfigMixin? configMixin;
+  final List<NavBarConfigMixin> configMixins;
 
   const ConfigPair(
     this.updater,
-    this.configMixin,
+    this.configMixins,
   );
 
   @override
-  List<Object?> get props => [updater, configMixin];
+  List<Object?> get props => [
+        updater,
+        configMixins,
+      ];
 }

--- a/lib/src/widget/nav_bar/data/nav_bar_config.dart
+++ b/lib/src/widget/nav_bar/data/nav_bar_config.dart
@@ -1,10 +1,13 @@
 import 'package:equatable/equatable.dart';
 import 'package:xayn_design/src/widget/nav_bar/data/nav_bar_item.dart';
+import 'package:xayn_design/src/widget/nav_bar/nav_bar.dart';
 import 'package:xayn_design/src/widget/nav_bar/widget/nav_bar.dart';
 
 enum NavBarType {
   card,
   backBtn,
+  hidden,
+  ignored,
 }
 
 class NavBarConfig extends Equatable {
@@ -16,14 +19,28 @@ class NavBarConfig extends Equatable {
   final bool isWidthExpanded;
   final NavBarType type;
 
+  const NavBarConfig._(
+    this.items,
+    this.isWidthExpanded,
+    this.type,
+  );
+
   const NavBarConfig(
     this.items, {
     this.isWidthExpanded = false,
-  }) : type = NavBarType.card;
+  })  : assert(items.length > 0, 'There should be at least one item'),
+        type = NavBarType.card;
 
   /// Use this constructor, if you need to hide [NavBar]
   /// when widget that use [NavBarConfig] is shown
-  factory NavBarConfig.hidden() => const NavBarConfig([]);
+  factory NavBarConfig.hidden() =>
+      const NavBarConfig._([], false, NavBarType.hidden);
+
+  /// Use this constructor, if you need to ignore
+  /// implementation of the [NavBarConfigMixin]
+  /// In this case previous in the widget tree [NavBarConfigMixin] will be used
+  factory NavBarConfig.ignored() =>
+      const NavBarConfig._([], false, NavBarType.ignored);
 
   NavBarConfig.backBtn(
     NavBarItemBackButton btn,
@@ -37,4 +54,14 @@ class NavBarConfig extends Equatable {
         isWidthExpanded,
         type,
       ];
+}
+
+extension NavBarTypeExtension on NavBarType {
+  bool get isCard => this == NavBarType.card;
+
+  bool get isBack => this == NavBarType.backBtn;
+
+  bool get isHidden => this == NavBarType.hidden;
+
+  bool get isIgnored => this == NavBarType.ignored;
 }

--- a/lib/src/widget/nav_bar/data/nav_bar_config.dart
+++ b/lib/src/widget/nav_bar/data/nav_bar_config.dart
@@ -16,20 +16,14 @@ class NavBarConfig extends Equatable {
   final bool isWidthExpanded;
   final NavBarType type;
 
-  NavBarConfig(
+  const NavBarConfig(
     this.items, {
     this.isWidthExpanded = false,
-  })  : assert(
-          items.where((element) => element.isHighlighted).length <= 1,
-          'There can be maximum one highlighted item',
-        ),
-        type = NavBarType.card;
+  }) : type = NavBarType.card;
 
   /// Use this constructor, if you need to hide [NavBar]
-  NavBarConfig.hide()
-      : items = [],
-        isWidthExpanded = false,
-        type = NavBarType.backBtn;
+  /// when widget that use [NavBarConfig] is shown
+  factory NavBarConfig.hidden() => const NavBarConfig([]);
 
   NavBarConfig.backBtn(
     NavBarItemBackButton btn,

--- a/lib/src/widget/nav_bar/utils/config_mixin.dart
+++ b/lib/src/widget/nav_bar/utils/config_mixin.dart
@@ -2,9 +2,12 @@ import 'package:xayn_design/src/widget/nav_bar/data/nav_bar_config.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 mixin NavBarConfigMixin {
-  /// If value is null - the previous in a tree [NavBarConfig] will be applied
-  /// If value is  not null - config will be shown.
-  /// If need to hide previous config, and show nothing
-  ///   (hide [NavBar] while widget shown) - use [NavBarConfig.hidden]
-  NavBarConfig? get navBarConfig;
+  /// This config will be used to shown data in the [NavBar]
+  /// To show back button - use [NavBarConfig.backBtn]
+  /// To hide [NavBar] for some screen/widget (make it invisible) - use [NavBarConfig.hidden]
+  /// To ignore the implementation of [NavBarConfigMixin] - use [NavBarConfig.ignored].
+  ///   In that case the previous in the widget tree [NavBarConfigMixin] will be used
+  ///
+  /// For more info please check [NavBarConfig]
+  NavBarConfig get navBarConfig;
 }

--- a/lib/src/widget/nav_bar/utils/config_mixin.dart
+++ b/lib/src/widget/nav_bar/utils/config_mixin.dart
@@ -1,5 +1,10 @@
 import 'package:xayn_design/src/widget/nav_bar/data/nav_bar_config.dart';
+import 'package:xayn_design/xayn_design.dart';
 
 mixin NavBarConfigMixin {
-  NavBarConfig get navBarConfig;
+  /// If value is null - the previous in a tree [NavBarConfig] will be applied
+  /// If value is  not null - config will be shown.
+  /// If need to hide previous config, and show nothing
+  ///   (hide [NavBar] while widget shown) - use [NavBarConfig.hidden]
+  NavBarConfig? get navBarConfig;
 }

--- a/lib/src/widget/nav_bar/utils/observer.dart
+++ b/lib/src/widget/nav_bar/utils/observer.dart
@@ -14,7 +14,7 @@ class NavBarObserver extends NavigatorObserver {
 
   @override
   void didRemove(Route route, Route? previousRoute) {
-    _resetNavBarConfig(true);
+    _resetNavBarConfig(false);
   }
 
   @override

--- a/lib/src/widget/nav_bar/widget/nav_bar.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar.dart
@@ -41,6 +41,11 @@ class _NavBarState extends State<NavBar> implements ConfigUpdater {
 
   @override
   void update(NavBarConfig? config) {
+    assert(
+      config?.type != NavBarType.ignored,
+      'This config should be ignored and should NOT be populated here',
+    );
+
     setState(() {
       this.config = config;
       if (config != null) {
@@ -55,7 +60,7 @@ class _NavBarState extends State<NavBar> implements ConfigUpdater {
   @override
   Widget build(BuildContext context) {
     final config = this.config;
-    if (config == null || config.items.isEmpty) return const Center();
+    if (config == null || config.type.isHidden) return const Center();
 
     final items = config.items.map(_buildItem).toList(growable: false);
 

--- a/lib/src/widget/nav_bar/widget/nav_bar.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar.dart
@@ -43,7 +43,7 @@ class _NavBarState extends State<NavBar> implements ConfigUpdater {
   void update(NavBarConfig? config) {
     assert(
       config?.type != NavBarType.ignored,
-      'This config should be ignored and should NOT be populated here',
+      'This config is ignored, so it can not be used to update the NavBar. This is likely a internal Bug.',
     );
 
     setState(() {

--- a/lib/src/widget/nav_bar/widget/nav_bar.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar.dart
@@ -43,6 +43,12 @@ class _NavBarState extends State<NavBar> implements ConfigUpdater {
   void update(NavBarConfig? config) {
     setState(() {
       this.config = config;
+      if (config != null) {
+        assert(
+          config.items.where((element) => element.isHighlighted).length <= 1,
+          'There can be maximum one highlighted item',
+        );
+      }
     });
   }
 

--- a/lib/src/widget/nav_bar/widget/nav_bar_container.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_container.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:xayn_design/src/widget/nav_bar/data/config_pair.dart';
+import 'package:xayn_design/src/widget/nav_bar/data/nav_bar_config.dart';
 import 'package:xayn_design/src/widget/nav_bar/widget/nav_bar.dart';
 import 'package:xayn_design/xayn_design.dart';
 
@@ -99,7 +100,7 @@ class _NavBarContainerState extends State<NavBarContainer>
   void _updateBar(ConfigPair configPair) {
     for (final mixin in configPair.configMixins.reversed) {
       final config = mixin.navBarConfig;
-      if (config != null) {
+      if (!config.type.isIgnored) {
         configPair.updater.update(config);
         return;
       }

--- a/lib/xayn_design.dart
+++ b/lib/xayn_design.dart
@@ -14,7 +14,6 @@ export 'src/linden/xcolors.dart' show XColors;
 export 'src/linden/xsizes.dart' show XSizes, Experiences;
 export 'src/linden/xstyles.dart' show XStyles;
 export 'src/utils/safe_platform.dart' show SafePlatform;
-export 'src/utils/design_testing_utils.dart';
 
 export 'src/widget/build_observer.dart';
 export 'src/widget/button/app_raised_button.dart';

--- a/lib/xayn_design_test.dart
+++ b/lib/xayn_design_test.dart
@@ -1,0 +1,7 @@
+/// Flutter widgets and design objects for Xayn Design library
+/// exposing [Linden] design object.
+///
+/// To use, import `package:xayn_design/xayn_design.dart`.
+library xayn_design;
+
+export 'src/utils/design_testing_utils.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_svg: '0.23.0+1'
   flutter_switch: 0.3.2
   provider: 6.0.1
+  rxdart: 0.27.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What 🕵️ 🔍

- Add debounce to the nav_bar_container.dart when reset or update methods are called
- remove the `postFrameCallback`s
- `NavBarConfigMixin` return a nullable value (for cases when we might want to show NavBar but also might need to ignore it)
- minor refactor `NavBarConfig`
  - from now we keep in the memory list of mixins
  - every time when `update` method is called, we go through the list and pick up the first `config` where `type != ignored`
  - we need it, cos sometimes _screen might change their mind_ and decide that they do not have content for the `NavBar` and then previous in tree `config` should be shown (please see `nav_bar_ignored_screen.dart` for more info)
  - if no configs are found (empty mixin list or 0 mixin return `config`) - the `navBar` will be hidden
  - if the screen do not have `config` to show, but still want to avoid the previous `NavBar` to be shown - `NavBarConfig.hidden()` should be used

----------

### How to test 🥼 🔬

- run the example app
- check example app

----------