### PR TITLE
Add optional navBarContainer wrapper to the XaynDesignWidgetTesterExt…

### DIFF
--- a/lib/src/utils/design_testing_utils.dart
+++ b/lib/src/utils/design_testing_utils.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xayn_design/src/linden/linden.dart';
+import 'package:xayn_design/src/widget/nav_bar/nav_bar.dart';
 import 'package:xayn_design/src/widget/unter_den_linden/unter_den_linden.dart';
 
 /// Helper extension functions for making testing easier for apps that use
@@ -13,17 +14,22 @@ extension XaynDesignWidgetTesterExtension on WidgetTester {
     Linden? initialLinden,
     ThemeData? theme,
     List<NavigatorObserver>? observers,
-  }) =>
-      pumpWidget(
-        _appWrappedWithLinden(
-          child: widget,
-          initialLinden: initialLinden,
-          theme: theme,
-          observers: observers,
-        ),
-        duration,
-        phase,
-      );
+    bool withNavBarContainer = false,
+  }) {
+    final child =
+        withNavBarContainer ? _appWrappedWithNavBarContainer(widget) : widget;
+    final withLinden = _appWrappedWithLinden(
+      child: child,
+      initialLinden: initialLinden,
+      theme: theme,
+      observers: observers,
+    );
+    return pumpWidget(
+      withLinden,
+      duration,
+      phase,
+    );
+  }
 }
 
 Widget _appWrappedWithLinden({
@@ -42,6 +48,15 @@ Widget _appWrappedWithLinden({
     initialLinden: linden,
   );
 }
+
+Widget _appWrappedWithNavBarContainer(Widget child) => NavBarContainer(
+      child: Stack(
+        children: [
+          Positioned.fill(child: child),
+          const Positioned.fill(top: null, child: NavBar())
+        ],
+      ),
+    );
 
 /// Can be used, when you need to find an element `byType` with the generic
 Type typeOf<T>() => T;


### PR DESCRIPTION
### What 🕵️ 🔍

- Add optional `navBarContainer` wrapper to the XaynDesignWidgetTesterExtension
- it is needed to provide propper widget tests

----------
