### PR TITLE
NavBar improvement

### DIFF
--- a/lib/src/linden/xstyles.dart
+++ b/lib/src/linden/xstyles.dart
@@ -60,6 +60,10 @@ class XStyles {
         height: 1.54,
       );
 
+  TextStyle? get appBodyTextSecondary => appBodyText?.copyWith(
+        color: colors.secondaryText,
+      );
+
   TextStyle? get appButtonText => appBodyText?.copyWith(
         fontWeight: _weightBold,
         fontSize: 13,

--- a/lib/src/widget/nav_bar/nav_bar.dart
+++ b/lib/src/widget/nav_bar/nav_bar.dart
@@ -7,4 +7,4 @@ export 'package:xayn_design/src/widget/nav_bar/utils/observer.dart';
 
 export 'package:xayn_design/src/widget/nav_bar/widget/nav_bar.dart' show NavBar;
 export 'package:xayn_design/src/widget/nav_bar/widget/nav_bar_container.dart'
-    show NavBarContainer;
+    show NavBarContainer, updateNabBarDebounceTimeout;

--- a/lib/src/widget/nav_bar/widget/nav_bar_container.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_container.dart
@@ -154,7 +154,7 @@ class NavBarContainerState extends State<NavBarContainer>
 
     if (ignoreLast &&
         list.isNotEmpty &&
-        list.last == currentNavBarConfigMixin) {
+        list.last.runtimeType == currentNavBarConfigMixin.runtimeType) {
       list.removeLast();
     }
     return ConfigPair(navBarState, list);

--- a/test/widget/nav_bar/widget/nav_bar_container_test.dart
+++ b/test/widget/nav_bar/widget/nav_bar_container_test.dart
@@ -416,7 +416,7 @@ void main() {
           await tester.pumpLindenApp(buildWidget(child: widget));
           final state = getState();
           state.currentNavBarConfigMixin =
-              _StatelessConfigWidget(() => _singleItemConfig);
+              _StatelessConfigWidget2(() => _backBtnConfig);
 
           await tester.resetNavBarWithDebounce(goingBack: true);
 
@@ -439,6 +439,28 @@ void main() {
 
           final state = getState();
           state.currentNavBarConfigMixin = lastMixin;
+
+          await tester.resetNavBarWithDebounce(goingBack: true);
+
+          expect(
+            state.configPair!.configMixins,
+            equals([preLastMixin]),
+          );
+        },
+      );
+      testWidgets(
+        'GIVEN widget tree with 1 config WHEN going back and and currentNavBarConfigMixin is same type but different instance THEN last config will be removed from the list',
+        (final WidgetTester tester) async {
+          final lastWidget = _StatelessConfigWidget(() => _singleItemConfig);
+          final previousWidget =
+              _StatelessConfigWidget(() => _backBtnConfig, child: lastWidget);
+          final NavBarConfigMixin preLastMixin = previousWidget;
+
+          await tester.pumpLindenApp(buildWidget(child: previousWidget));
+
+          final state = getState();
+          state.currentNavBarConfigMixin =
+              _StatelessConfigWidget(() => _singleItemConfig);
 
           await tester.resetNavBarWithDebounce(goingBack: true);
 

--- a/test/widget/nav_bar/widget/nav_bar_container_test.utils.dart
+++ b/test/widget/nav_bar/widget/nav_bar_container_test.utils.dart
@@ -57,6 +57,11 @@ NavBarContainer buildWidget({
 
 typedef GetConfigCallback = NavBarConfig Function();
 
+class _StatelessConfigWidget2 extends _StatelessConfigWidget {
+  const _StatelessConfigWidget2(GetConfigCallback getConfigCallback)
+      : super(getConfigCallback);
+}
+
 class _StatelessConfigWidget extends StatelessWidget with NavBarConfigMixin {
   final Widget? child;
   final GetConfigCallback getConfigCallback;


### PR DESCRIPTION
- covered with the test

### What 🕵️ 🔍

- Remove last navBar mixin from the list when the `runtimeType` is the same
- before we compare the same instance. But with the changed theme (for example) instance is also changed, which create undesired behavior

----------

### How to test 🥼 🔬

- I added the test, that cover that case
