### PR TITLE
TB-3238 Make tap area bigger for settings tile action icon

### DIFF
--- a/lib/src/widget/settings/data/settings_tile_action.dart
+++ b/lib/src/widget/settings/data/settings_tile_action.dart
@@ -1,6 +1,22 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 
+enum SettingsTileActionTapArea {
+  content,
+  trailing,
+}
+
+extension SettingsTileActionExtension on SettingsTileAction {
+  SettingsTileActionTapArea get tapArea {
+    switch (runtimeType) {
+      case SettingsTileActionIcon:
+        return SettingsTileActionTapArea.content;
+      default:
+        return SettingsTileActionTapArea.trailing;
+    }
+  }
+}
+
 @immutable
 abstract class SettingsTileAction extends Equatable {
   final Key key;

--- a/lib/src/widget/settings/widget/settings_tile.dart
+++ b/lib/src/widget/settings/widget/settings_tile.dart
@@ -24,15 +24,28 @@ class SettingsTile extends StatelessWidget {
       children: rowChildren,
       crossAxisAlignment: CrossAxisAlignment.start,
     );
-    return SizedBox(
-        height: linden.dimen.unit7,
-        child: Padding(
-          padding: EdgeInsets.only(
-            left: linden.dimen.unit2,
-            right: linden.dimen.unit0_5,
-          ),
-          child: row,
-        ));
+
+    final content = SizedBox(
+      height: linden.dimen.unit7,
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: linden.dimen.unit2,
+          right: linden.dimen.unit0_5,
+        ),
+        child: row,
+      ),
+    );
+
+    final embedInButton =
+        data.action?.tapArea == SettingsTileActionTapArea.content;
+    return embedInButton
+        ? AppGhostButton(
+            key: data.action?.key,
+            onPressed: data.action?.onPressed,
+            contentPadding: EdgeInsets.zero,
+            child: content,
+          )
+        : content;
   }
 
   void _addIcon(Linden linden, List<Widget> rowChildren) {
@@ -133,14 +146,27 @@ class SettingsTile extends StatelessWidget {
         minSizeEqual: true,
       );
 
+  // Widget _buildActionIcon(SettingsTileActionIcon action, Linden linden) =>
+  //     SizedBox(
+  //       width: linden.dimen.iconButtonSize,
+  //       height: linden.dimen.iconButtonSize,
+  //       child: AppGhostButton.icon(
+  //         action.svgIconPath,
+  //         key: action.key,
+  //         onPressed: action.onPressed,
+  //       ),
+  //     );
+
   Widget _buildActionIcon(SettingsTileActionIcon action, Linden linden) =>
       SizedBox(
         width: linden.dimen.iconButtonSize,
         height: linden.dimen.iconButtonSize,
-        child: AppGhostButton.icon(
+        child: SvgPicture.asset(
           action.svgIconPath,
-          key: action.key,
-          onPressed: action.onPressed,
+          fit: BoxFit.none,
+          width: linden.dimen.iconSize,
+          height: linden.dimen.iconSize,
+          color: linden.colors.icon,
         ),
       );
 

--- a/lib/src/widget/settings/widget/settings_tile.dart
+++ b/lib/src/widget/settings/widget/settings_tile.dart
@@ -146,17 +146,6 @@ class SettingsTile extends StatelessWidget {
         minSizeEqual: true,
       );
 
-  // Widget _buildActionIcon(SettingsTileActionIcon action, Linden linden) =>
-  //     SizedBox(
-  //       width: linden.dimen.iconButtonSize,
-  //       height: linden.dimen.iconButtonSize,
-  //       child: AppGhostButton.icon(
-  //         action.svgIconPath,
-  //         key: action.key,
-  //         onPressed: action.onPressed,
-  //       ),
-  //     );
-
   Widget _buildActionIcon(SettingsTileActionIcon action, Linden linden) =>
       SizedBox(
         width: linden.dimen.iconButtonSize,

--- a/test/widget/settings/data/settings_tile_data_test.dart
+++ b/test/widget/settings/data/settings_tile_data_test.dart
@@ -35,41 +35,4 @@ void main() {
       expect(action.tapArea, SettingsTileActionTapArea.content);
     },
   );
-
-  test(
-    'GIVEN settings tile action text WHEN tap area called THEN return trailing',
-    () {
-      final action = SettingsTileActionText(
-        key: const Key('tile'),
-        onPressed: onPressed,
-        text: 'text',
-      );
-      expect(action.tapArea, SettingsTileActionTapArea.trailing);
-    },
-  );
-
-  test(
-    'GIVEN settings tile action circle WHEN tap area called THEN return trailing',
-    () {
-      final action = SettingsTileActionCircle(
-        key: const Key('tile'),
-        onPressed: onPressed,
-        isActive: true,
-        svgIconPath: 'svgIconPath',
-      );
-      expect(action.tapArea, SettingsTileActionTapArea.trailing);
-    },
-  );
-
-  test(
-    'GIVEN settings tile action switch WHEN tap area called THEN return trailing',
-    () {
-      final action = SettingsTileActionSwitch(
-        key: const Key('tile'),
-        onPressed: onPressed,
-        value: true,
-      );
-      expect(action.tapArea, SettingsTileActionTapArea.trailing);
-    },
-  );
 }

--- a/test/widget/settings/data/settings_tile_data_test.dart
+++ b/test/widget/settings/data/settings_tile_data_test.dart
@@ -23,4 +23,53 @@ void main() {
       expect(full() == full(), isTrue);
     },
   );
+
+  test(
+    'GIVEN settings tile action icon WHEN tap area called THEN return content',
+    () {
+      final action = SettingsTileActionIcon(
+        key: const Key('tile'),
+        onPressed: onPressed,
+        svgIconPath: 'svgIconPath',
+      );
+      expect(action.tapArea, SettingsTileActionTapArea.content);
+    },
+  );
+
+  test(
+    'GIVEN settings tile action text WHEN tap area called THEN return trailing',
+    () {
+      final action = SettingsTileActionText(
+        key: const Key('tile'),
+        onPressed: onPressed,
+        text: 'text',
+      );
+      expect(action.tapArea, SettingsTileActionTapArea.trailing);
+    },
+  );
+
+  test(
+    'GIVEN settings tile action circle WHEN tap area called THEN return trailing',
+    () {
+      final action = SettingsTileActionCircle(
+        key: const Key('tile'),
+        onPressed: onPressed,
+        isActive: true,
+        svgIconPath: 'svgIconPath',
+      );
+      expect(action.tapArea, SettingsTileActionTapArea.trailing);
+    },
+  );
+
+  test(
+    'GIVEN settings tile action switch WHEN tap area called THEN return trailing',
+    () {
+      final action = SettingsTileActionSwitch(
+        key: const Key('tile'),
+        onPressed: onPressed,
+        value: true,
+      );
+      expect(action.tapArea, SettingsTileActionTapArea.trailing);
+    },
+  );
 }


### PR DESCRIPTION
### What 🕵️ 🔍

Make the whole content tappable when using settings tile action icon.

----------

### How to test 🥼 🔬

Can be tested in the parent PR: https://github.com/xaynetwork/xayn_discovery_app/pull/138

----------


### References 📝 🔗

- [TB-3238](https://xainag.atlassian.net/browse/TB-3238)

----------