### PR TITLE
TB-3223 Add missing keyboardAppearance setting to NavBarEdit

### DIFF
--- a/lib/src/widget/nav_bar/widget/nav_bar_item/edit.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_item/edit.dart
@@ -92,6 +92,7 @@ class _NavBarEditState extends State<NavBarEdit> {
         controller: controller,
         style: linden.styles.textInputTextSmall,
         textInputAction: TextInputAction.search,
+        keyboardAppearance: linden.colors.brightness,
         maxLines: 1,
         onChanged: widget.data.onTextChanged,
         onSubmitted: widget.data.onSearchPressed,


### PR DESCRIPTION
### What 🕵️ 🔍

Solves an issue where the keyboard theme doesn't automatically update to match app theme (iOS only). 

----------

### How to test 🥼 🔬

Can be tested on active search (temporary enabled) in parent PR: <WIP>


### References 📝 🔗

- [TB-3223](https://xainag.atlassian.net/browse/TB-3223)

----------