### PR TITLE
TB-3271 Nav bar UI adjustments

### DIFF
--- a/lib/src/linden/linden.dart
+++ b/lib/src/linden/linden.dart
@@ -219,7 +219,7 @@ ThemeData _defaultTheme(
     appBarTheme: AppBarTheme(color: colors.accent),
     dialogBackgroundColor: colors.background,
     dividerColor: colors.divider,
-    scaffoldBackgroundColor: colors.background,
+    scaffoldBackgroundColor: colors.pageBackground,
     unselectedWidgetColor: colors.iconDisabled,
   );
   if (styles != null) {

--- a/lib/src/linden/xcolors.dart
+++ b/lib/src/linden/xcolors.dart
@@ -108,6 +108,9 @@ class XColors {
   Color get shadowTransparent =>
       _theme(bright: _black.withAlpha(65), dark: _black.withAlpha(0));
 
+  Color get shadowTransparentLigher =>
+      _theme(bright: _black.withAlpha(24), dark: _black.withAlpha(0));
+
   Color get shadowTransparentDarker =>
       _theme(bright: _black.withAlpha(100), dark: _black.withAlpha(0));
 

--- a/lib/src/linden/xcolors.dart
+++ b/lib/src/linden/xcolors.dart
@@ -109,7 +109,7 @@ class XColors {
       _theme(bright: _black.withAlpha(65), dark: _black.withAlpha(0));
 
   Color get shadowTransparentLigher =>
-      _theme(bright: _black.withAlpha(24), dark: _black.withAlpha(0));
+      _theme(bright: _black.withAlpha(24), dark: _transparent);
 
   Color get shadowTransparentDarker =>
       _theme(bright: _black.withAlpha(100), dark: _black.withAlpha(0));
@@ -402,6 +402,10 @@ class NewXColors extends XColors {
 
   @override
   Color get collectionsScreenCard => _theme(bright: _pink60);
+
+  @override
+  Color get shadowTransparentLigher =>
+      _theme(bright: _black10, dark: transparent);
 }
 
 class _NewSchemeException implements Exception {

--- a/lib/src/linden/xsizes.dart
+++ b/lib/src/linden/xsizes.dart
@@ -31,6 +31,7 @@ class XSizes {
   final double unit0_25 = _unit * 0.25;
   final double unit0_5 = _unit * 0.5;
   final double unit0_75 = _unit * 0.75;
+  final double unit1_25 = _unit * 1.25;
   final double unit1_5 = _unit * 1.5;
   final double unit2 = _unit * 2;
   final double unit2_25 = _unit * 2.25;

--- a/lib/src/linden/xstyles.dart
+++ b/lib/src/linden/xstyles.dart
@@ -172,6 +172,12 @@ class XStyles {
         fontSize: 14.0,
       );
 
+  BoxShadow get cardShadow => BoxShadow(
+        color: colors.shadowTransparentLigher,
+        blurRadius: 10,
+        spreadRadius: 4,
+      );
+
   BoxShadow get suggestionContainerShadow => BoxShadow(
         color: colors.searchSuggetsionShadow,
         blurRadius: 4,

--- a/lib/src/linden/xstyles.dart
+++ b/lib/src/linden/xstyles.dart
@@ -174,8 +174,8 @@ class XStyles {
 
   BoxShadow get cardShadow => BoxShadow(
         color: colors.shadowTransparentLigher,
-        blurRadius: 10,
-        spreadRadius: 4,
+        blurRadius: _dimen.unit1_25,
+        spreadRadius: _dimen.unit0_5,
       );
 
   BoxShadow get suggestionContainerShadow => BoxShadow(

--- a/lib/src/widget/nav_bar/widget/nav_bar.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar.dart
@@ -63,11 +63,16 @@ class NavBarState extends State<NavBar> implements ConfigUpdater {
       children: items,
     );
 
-    final card = AppCardWidget(
-      contentPadding: EdgeInsets.symmetric(horizontal: linden.dimen.unit),
+    // AppCardWidget can't be used becasue it uses Material widget
+    // with MaterialType.card, which doesn't allow to customise shadows.
+    final card = Container(
+      padding: EdgeInsets.symmetric(horizontal: linden.dimen.unit),
       child: row,
-      borderRadius: BorderRadius.all(Radius.circular(linden.dimen.unit1_5)),
-      cardBackground: linden.colors.background,
+      decoration: BoxDecoration(
+        color: linden.colors.background,
+        borderRadius: BorderRadius.circular(linden.dimen.unit1_5),
+        boxShadow: [linden.styles.cardShadow],
+      ),
     );
 
     final sized = _withFixedHeight(card);

--- a/lib/src/widget/nav_bar/widget/nav_bar_item/edit.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_item/edit.dart
@@ -66,9 +66,12 @@ class _NavBarEditState extends State<NavBarEdit> {
         borderRadius: BorderRadius.circular(linden.dimen.unit),
       ),
     );
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: linden.dimen.unit0_25),
-      child: container,
+    return Material(
+      color: Colors.transparent,
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: linden.dimen.unit0_25),
+        child: container,
+      ),
     );
   }
 

--- a/lib/src/widget/nav_bar/widget/nav_bar_item/edit.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_item/edit.dart
@@ -67,7 +67,7 @@ class _NavBarEditState extends State<NavBarEdit> {
       ),
     );
     return Material(
-      color: Colors.transparent,
+      color: linden.colors.transparent,
       child: Padding(
         padding: EdgeInsets.symmetric(horizontal: linden.dimen.unit0_25),
         child: container,
@@ -83,6 +83,7 @@ class _NavBarEditState extends State<NavBarEdit> {
       color: linden.colors.icon,
     );
     return InkWell(
+      splashColor: linden.colors.splashColor,
       onTap: widget._focusNode.requestFocus,
       child: Center(child: icon),
       borderRadius: BorderRadius.circular(linden.dimen.unit),

--- a/lib/src/widget/nav_bar/widget/nav_bar_item/icon_button.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_item/icon_button.dart
@@ -15,12 +15,15 @@ class NavBarIconButton extends StatelessWidget {
       height: linden.dimen.iconSize,
       color: data.isDisabled ? linden.colors.iconDisabled : linden.colors.icon,
     );
-    final btn = InkWell(
-      key: data.key,
-      onTap: data.onPressed,
-      onLongPress: data.onLongPressed,
-      child: Center(child: icon),
-      borderRadius: BorderRadius.circular(linden.dimen.unit),
+    final btn = Material(
+      color: Colors.transparent,
+      child: InkWell(
+        key: data.key,
+        onTap: data.onPressed,
+        onLongPress: data.onLongPressed,
+        child: Center(child: icon),
+        borderRadius: BorderRadius.circular(linden.dimen.unit),
+      ),
     );
 
     return SizedBox(

--- a/lib/src/widget/nav_bar/widget/nav_bar_item/icon_button.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_item/icon_button.dart
@@ -16,8 +16,9 @@ class NavBarIconButton extends StatelessWidget {
       color: data.isDisabled ? linden.colors.iconDisabled : linden.colors.icon,
     );
     final btn = Material(
-      color: Colors.transparent,
+      color: linden.colors.transparent,
       child: InkWell(
+        splashColor: linden.colors.splashColor,
         key: data.key,
         onTap: data.onPressed,
         onLongPress: data.onLongPressed,

--- a/test/widget/nav_bar/widget/nav_bar_test.dart
+++ b/test/widget/nav_bar/widget/nav_bar_test.dart
@@ -150,7 +150,6 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.byType(AppCardWidget), findsOneWidget);
         expect(find.byType(Row), findsNWidgets(3));
         expect(find.byType(SafeArea), findsOneWidget);
         expect(find.byType(HighlightLine), findsNothing);


### PR DESCRIPTION
### What 🕵️ 🔍

- Wrap Nav Bar in `Container` instead of `AppCardWidget` in order to customise shadows
- Change `scaffoldBackgroundColor` to use `pageBackground` as per designs
- Wrap each button in `Material` widget with transparent background to keep the ripple effect when tapped

----------

### How to test 🥼 🔬

Cna be tested in parent PR: https://github.com/xaynetwork/xayn_discovery_app/pull/168


----------

### References 📝 🔗

- [TB-3271](https://xainag.atlassian.net/browse/TB-3271)

----------