### PR TITLE
TB-3332 Fix nav bar shadow + remove shadow from back button

### DIFF
--- a/lib/src/linden/xcolors.dart
+++ b/lib/src/linden/xcolors.dart
@@ -402,10 +402,6 @@ class NewXColors extends XColors {
 
   @override
   Color get collectionsScreenCard => _theme(bright: _pink60);
-
-  @override
-  Color get shadowTransparentLigher =>
-      _theme(bright: _black10, dark: transparent);
 }
 
 class _NewSchemeException implements Exception {

--- a/lib/src/widget/nav_bar/widget/nav_bar_item/back_button.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_item/back_button.dart
@@ -12,6 +12,7 @@ class NavBarBackButton extends StatelessWidget {
     final fab = FloatingActionButton.large(
       key: data.key,
       backgroundColor: linden.colors.primaryAction,
+      elevation: 0,
       onPressed: data.onPressed,
       child: SvgPicture.asset(
         linden.assets.icons.arrowLeft,


### PR DESCRIPTION
### What 🕵️ 🔍

- Fixes wrong nav bar shadow.
- Removes shadow from the back button as per designs.

----------

### How to test 🥼 🔬

Can be tested in parent PR: https://github.com/xaynetwork/xayn_discovery_app/pull/178

----------

### References 📝 🔗

- [TB-3332](https://xainag.atlassian.net/browse/TB-3332)

----------