### PR TITLE
TB-3360 Fix SettingsSelectableIcon text color

### DIFF
--- a/lib/src/widget/settings/widget/settings_selectable.dart
+++ b/lib/src/widget/settings/widget/settings_selectable.dart
@@ -108,7 +108,7 @@ class SettingsSelectableIcon extends StatelessWidget {
       textAlign: TextAlign.center,
       style: linden.styles.sBoldStyle.copyWith(
         color: item.isSelected
-            ? linden.colors.primaryTextInverse
+            ? linden.colors.brightText
             : linden.colors.secondaryText,
       ),
     );


### PR DESCRIPTION
### What 🕵️ 🔍

Fix a color issue with the SettingsSelectableIcon widget

----------

### References 📝 🔗

- [TB-3360](https://xainag.atlassian.net/browse/TB-3360)

----------