### PR TITLE
TB-3494 swipeCardBackgroundHome color

### DIFF
--- a/lib/src/linden/xcolors.dart
+++ b/lib/src/linden/xcolors.dart
@@ -263,7 +263,7 @@ class XColors {
 
   Color get swipeCardBackgroundDefault => _black;
 
-  Color get swipeCardBackgroundHome => _grey.shade95;
+  Color get swipeCardBackgroundHome => _black;
 
   Color get snippetBackground => _white;
 


### PR DESCRIPTION
### What 🕵️ 🔍

- change `swipeCardBackgroundHome` color to make it visible, when there is no image

----------

### References 📝 🔗

- [jira ticket](https://xainag.atlassian.net/browse/TB-3496)
- [figma design](https://www.figma.com/file/hGAst3K9ZQIHmQoCNjbgaZ/Discovery-App-%7C-Design?node-id=1316%3A4013)

----------