### PR TITLE
Tb 3642 breack lines in tooltips for long text

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,17 +39,22 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final linden = UnterDenLinden.getLinden(context);
     final materialApp = MaterialApp(
       title: 'Flutter Demo',
-      theme: UnterDenLinden.getLinden(context).themeData,
+      theme: linden.themeData,
       onGenerateRoute: createCupertinoPageRoute,
       navigatorObservers: [NavBarObserver()],
     );
 
+    final padding = EdgeInsets.symmetric(
+      horizontal: linden.dimen.navBarSidePadding,
+      vertical: linden.dimen.navBarBottomPadding,
+    );
     final stack = Stack(
       children: [
         materialApp,
-        const Positioned.fill(top: null, child: NavBar()),
+        Positioned.fill(top: null, child: NavBar(padding: padding)),
       ],
     );
 

--- a/example/lib/screen/xayn_widgets/page/tooltip_page.dart
+++ b/example/lib/screen/xayn_widgets/page/tooltip_page.dart
@@ -26,6 +26,8 @@ class _TooltipPageState extends State<TooltipPage> with TooltipStateMixin {
       children: [
         _buildSimpleTooltipBtn(),
         _buildTooltipWithIcon(),
+        _buildTooltipWith2LinesText(),
+        _buildTooltipWithLongText(),
         const SizedBox(height: 30),
         _buildAnchorWidget(linden),
       ],
@@ -59,6 +61,16 @@ class _TooltipPageState extends State<TooltipPage> with TooltipStateMixin {
 
   Widget _buildTooltipWithIcon() => _buildButton('Show tooltip with Icon', () {
         showTooltip(TooltipKeys.withIcon);
+      });
+
+  Widget _buildTooltipWith2LinesText() =>
+      _buildButton('Show 2 lines tooltip', () {
+        showTooltip(TooltipKeys.twoLines);
+      });
+
+  Widget _buildTooltipWithLongText() =>
+      _buildButton('Show long text tooltip', () {
+        showTooltip(TooltipKeys.longText);
       });
 
   Widget _buildButton(String text, VoidCallback onPressed) => Center(

--- a/example/lib/utils/tooltip_keys.dart
+++ b/example/lib/utils/tooltip_keys.dart
@@ -5,6 +5,8 @@ class TooltipKeys {
 
   static const simple = TooltipKey('simple');
   static const withIcon = TooltipKey('with_icon');
+  static const twoLines = TooltipKey('two_lines');
+  static const longText = TooltipKey('long_text');
 }
 
 abstract class TooltipMessageProvider {
@@ -13,6 +15,16 @@ abstract class TooltipMessageProvider {
   static MessageFactory of() => {
         TooltipKeys.simple: TooltipParams(
           label: 'This is simple tooltip',
+          builder: (_) => const TextualNotification(),
+        ),
+        TooltipKeys.longText: TooltipParams(
+          label: 'Hi there! This is a tooltip message with the extremely very long-long long text',
+          builder: (_) => CustomizedTextualNotification(
+            icon: UnterDenLinden.getLinden(_).assets.icons.info,
+          ),
+        ),
+        TooltipKeys.twoLines: TooltipParams(
+          label: 'This is tooltip message\nwith 2 lines',
           builder: (_) => const TextualNotification(),
         ),
       };

--- a/lib/src/linden/xsizes.dart
+++ b/lib/src/linden/xsizes.dart
@@ -129,6 +129,8 @@ class XSizes {
 
   double get navBarBottomPadding => unit3;
 
+  double get navBarSidePadding => unit4;
+
   double get inputTextFieldBorderWidth => 1.5;
 
   double get readerModeBottomPadding =>

--- a/lib/src/widget/tooltip/widget/messages/customized_textual_notification.dart
+++ b/lib/src/widget/tooltip/widget/messages/customized_textual_notification.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/src/utils/text_utils.dart';
-import 'package:xayn_design/src/widget/unter_den_linden/unter_den_linden_mixin.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 const Duration _kTimeToLive = Duration(seconds: 3);
@@ -33,11 +32,11 @@ class CustomizedTextualNotification extends TooltipMessage {
   }) : super(key: key, timeToLive: _kTimeToLive);
 
   @override
-  State<StatefulWidget> createState() => _TextualNotificationState();
+  TooltipMessageState createState() => _TextualNotificationState();
 }
 
-class _TextualNotificationState extends State<CustomizedTextualNotification>
-    with TooltipControllerProviderMixin, UnterDenLindenMixin {
+class _TextualNotificationState
+    extends TooltipMessageState<CustomizedTextualNotification> {
   String? get highlightText => widget.highlightText;
 
   TextStyle? get labelTextStyle =>
@@ -85,21 +84,13 @@ class _TextualNotificationState extends State<CustomizedTextualNotification>
 
         tooltipController.hide();
       },
-      child: TooltipMessageContainer(
-        linden: linden,
-        style: tooltipController.activeStyle,
-        child: content,
-      ),
+      child: buildTooltipContainer(content),
     );
   }
 
   Widget _getText(String text) {
     if (highlightText == null) {
-      return Text(
-        text,
-        textAlign: TextAlign.center,
-        style: labelTextStyle,
-      );
+      return buildText(style: labelTextStyle);
     }
 
     return getHighlightedText(

--- a/lib/src/widget/tooltip/widget/messages/textual_notification.dart
+++ b/lib/src/widget/tooltip/widget/messages/textual_notification.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:xayn_design/src/widget/unter_den_linden/unter_den_linden_mixin.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 const Duration kTimeToLive = Duration(seconds: 3);
@@ -20,11 +19,11 @@ class TextualNotification extends TooltipMessage {
   }) : super(key: key, timeToLive: kTimeToLive);
 
   @override
-  State<StatefulWidget> createState() => _TextualNotificationState();
+  TooltipMessageState createState() => _TextualNotificationState();
 }
 
-class _TextualNotificationState extends State<TextualNotification>
-    with TooltipControllerProviderMixin, UnterDenLindenMixin {
+class _TextualNotificationState
+    extends TooltipMessageState<TextualNotification> {
   @override
   Widget build(BuildContext context) {
     final icon = widget.icon;
@@ -33,7 +32,7 @@ class _TextualNotificationState extends State<TextualNotification>
       mainAxisSize: MainAxisSize.min,
       children: [
         if (icon != null) ...[
-          SvgPicture.asset(
+          buildIcon(
             icon,
             color: linden.colors.primary,
           ),
@@ -41,13 +40,7 @@ class _TextualNotificationState extends State<TextualNotification>
             width: linden.dimen.unit,
           )
         ],
-        if (tooltipController.activeKey != null)
-          Flexible(
-            child: Text(
-              tooltipController.keyToLabel(tooltipController.activeKey!),
-              textAlign: TextAlign.center,
-            ),
-          ),
+        if (tooltipController.activeKey != null) Flexible(child: buildText()),
       ],
     );
 
@@ -59,11 +52,7 @@ class _TextualNotificationState extends State<TextualNotification>
 
         tooltipController.hide();
       },
-      child: TooltipMessageContainer(
-        linden: linden,
-        style: tooltipController.activeStyle,
-        child: content,
-      ),
+      child: buildTooltipContainer(content),
     );
   }
 }

--- a/lib/src/widget/tooltip/widget/messages/tooltip_message.dart
+++ b/lib/src/widget/tooltip/widget/messages/tooltip_message.dart
@@ -3,12 +3,43 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
+import 'package:xayn_design/src/widget/unter_den_linden/unter_den_linden_mixin.dart';
 import 'package:xayn_design/xayn_design.dart';
 
 abstract class TooltipMessage extends StatefulWidget {
   final Duration timeToLive;
 
   const TooltipMessage({Key? key, required this.timeToLive}) : super(key: key);
+
+  @override
+  TooltipMessageState createState();
+}
+
+abstract class TooltipMessageState<T extends TooltipMessage> extends State<T>
+    with TooltipControllerProviderMixin, UnterDenLindenMixin {
+  SvgPicture buildIcon(
+    String svgIconPath, {
+    Color? color,
+  }) =>
+      SvgPicture.asset(
+        svgIconPath,
+        color: color ?? linden.colors.primary,
+      );
+
+  Text buildText({TextStyle? style}) => Text(
+        tooltipController.keyToLabel(tooltipController.activeKey!),
+        maxLines: 2,
+        textAlign: TextAlign.center,
+        overflow: TextOverflow.ellipsis,
+        style: style,
+      );
+
+  TooltipMessageContainer buildTooltipContainer(Widget child) =>
+      TooltipMessageContainer(
+        linden: linden,
+        style: tooltipController.activeStyle,
+        child: child,
+      );
 }
 
 mixin TooltipControllerProviderMixin<T extends TooltipMessage> on State<T> {
@@ -56,7 +87,7 @@ class TooltipMessageContainer extends StatelessWidget
   Widget _buildNormalStyleWithChild(Widget? child) {
     return Padding(
       padding: EdgeInsets.symmetric(
-        horizontal: linden.dimen.unit2,
+        horizontal: linden.dimen.navBarSidePadding,
       ),
       child: Material(
         type: MaterialType.button,


### PR DESCRIPTION
### What 🕵️ 🔍

- set max lines for tooltip to 2
- update padding for tooltips
- minor refactoring

----------

### How to test 🥼 🔬

- run example app
- open xayn widgets
- play with tooltips

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <img width="280" src=""> | <img width="280" src="https://user-images.githubusercontent.com/12133914/162979244-cba2d164-8377-4aae-9504-f002c329b37e.png"> |
| <img width="280" src=""> | <img width="280" src="https://user-images.githubusercontent.com/12133914/162979254-835b2f46-d438-452a-ad9c-f6161e06ca3e.png"> |
| <img width="280" src=""> | <img width="280" src="https://user-images.githubusercontent.com/12133914/162979265-0898cc53-a8c7-47c7-8b00-eae3eba4a3c5.png"> |

----------

### References 📝 🔗

- [Jira tastk](https://xainag.atlassian.net/browse/TB-3642)

----------