### PR TITLE
TB-3771 NavBar back button fix (1/2)

### DIFF
--- a/lib/src/widget/nav_bar/widget/nav_bar_container.dart
+++ b/lib/src/widget/nav_bar/widget/nav_bar_container.dart
@@ -205,8 +205,7 @@ class NavBarContainerState extends State<NavBarContainer>
 
     if (ignoreLast &&
         list.isNotEmpty &&
-        list.last.navBarConfig.id ==
-            currentNavBarConfigMixin?.navBarConfig.id) {
+        list.last.navBarConfig == currentNavBarConfigMixin?.navBarConfig) {
       list.removeLast();
     }
     return ConfigPair(navBarState, list);


### PR DESCRIPTION
### What 🕵️ 🔍

When there are two pages with back nav button, comparing config IDs is not enough as back buttons have the same ID. This PR changes that so we only remove a mixing from the list when configs are the same.

----------

### How to test 🥼 🔬

Test parent PR: WIP


### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-3771)

----------